### PR TITLE
Fixes an issue where billing roles were not retrieved for documents

### DIFF
--- a/src/v2/connectors/repository/queries/document-roles.js
+++ b/src/v2/connectors/repository/queries/document-roles.js
@@ -5,14 +5,19 @@ select
   c.company_number, c.name, c.type AS company_type,
   a.address_1, a.address_2, a.address_3, a.address_4, a.town, a.county, a.postcode, a.country,
   c2.salutation, c2.first_name, c2.middle_names, c2.last_name, c2.initials,
-  i.invoice_account_number
+  i.invoice_account_number,
+  ic.company_number as invoice_number,
+  ic.company_id AS invoice_company_id,
+  ic.name AS invoice_company_name,
+  ic.company_number AS invoice_company_number
 
 from crm_v2.document_roles r
 join crm_v2.roles r2 ON r.role_id=r2.role_id
-join crm_v2.companies c on r.company_id=c.company_id
+left join crm_v2.companies c on r.company_id=c.company_id
 left join crm_v2.addresses a on r.address_id=a.address_id
 left join crm_v2.contacts c2 on r.contact_id=c2.contact_id
 left join crm_v2.invoice_accounts i on r.invoice_account_id=i.invoice_account_id
+left join crm_v2.companies ic on i.company_id=ic.company_id
 
-where r.document_id=$1;
+where document_id=$1
 `;

--- a/src/v2/modules/documents/lib/mappers.js
+++ b/src/v2/modules/documents/lib/mappers.js
@@ -10,9 +10,26 @@ const mapEntity = (row, fields) => {
     : camelCaseKeys(pick(row, fields));
 };
 
+/**
+ * Maps a row retrieved from the DB to a company
+ * For billing role, this is the company linked to the invoice account
+ * @param {Object} row - the DB row
+ * @return {Object} company
+ */
+const mapCompany = row => {
+  if (row.role_name === 'billing') {
+    return {
+      companyId: row.invoice_company_id,
+      name: row.invoice_company_name,
+      companyNumber: row.invoice_company_number
+    };
+  }
+  return mapEntity(row, ['company_id', 'name', 'company_number']);
+};
+
 const mapDocumentRole = row => ({
   ...mapEntity(row, ['document_role_id', 'role_id', 'role_name', 'start_date', 'end_date']),
-  company: mapEntity(row, ['company_id', 'name', 'company_number']),
+  company: mapCompany(row),
   contact: mapEntity(row, ['contact_id', 'salutation', 'first_name', 'last_name', 'middle_names']),
   address: mapEntity(row, ['address_id', 'address_1', 'address_2', 'address_3', 'address_4', 'town', 'county', 'postcode', 'country']),
   invoiceAccount: mapEntity(row, ['invoice_account_id', 'invoice_account_number'])

--- a/test/v2/modules/documents/lib/mappers.js
+++ b/test/v2/modules/documents/lib/mappers.js
@@ -2,6 +2,36 @@ const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').scri
 const { expect } = require('@hapi/code');
 const mappers = require('../../../../../src/v2/modules/documents/lib/mappers');
 
+const createRow = roleName => ({
+  document_role_id: 'role_1',
+  role_id: 'role_id_1',
+  role_name: roleName || 'role_name',
+  start_date: '2019-01-01',
+  end_date: '2019-12-31',
+  company_id: 'company_1',
+  name: 'company',
+  company_number: '12345',
+  contact_id: 'contact_1',
+  salutation: 'Dr',
+  first_name: 'John',
+  middle_names: 'A',
+  last_name: 'Doe',
+  address_id: 'address_1',
+  address_1: 'Daisy cottage',
+  address_2: 'Buttercup lane',
+  address_3: 'Dandelion road',
+  address_4: 'Poppy field',
+  town: 'Testington',
+  county: 'Testingshire',
+  postcode: 'AB1 2CD',
+  country: 'UK',
+  invoice_account_id: 'invoice_account_1',
+  invoice_account_number: 'A12345',
+  invoice_company_id: 'invoice_company_1',
+  invoice_company_name: 'Big Co 2',
+  invoice_company_number: '33434343'
+});
+
 experiment('v2/modules/documents/lib/mappers', () => {
   experiment('camelCaseKeys', () => {
     test('converts object keys to camel case', async () => {
@@ -41,97 +71,86 @@ experiment('v2/modules/documents/lib/mappers', () => {
   });
 
   experiment('mapDocumentRole', () => {
-    const row = {
-      document_role_id: 'role_1',
-      role_id: 'role_id_1',
-      role_name: 'role_name',
-      start_date: '2019-01-01',
-      end_date: '2019-12-31',
-      company_id: 'company_1',
-      name: 'company',
-      company_number: '12345',
-      contact_id: 'contact_1',
-      salutation: 'Dr',
-      first_name: 'John',
-      middle_names: 'A',
-      last_name: 'Doe',
-      address_id: 'address_1',
-      address_1: 'Daisy cottage',
-      address_2: 'Buttercup lane',
-      address_3: 'Dandelion road',
-      address_4: 'Poppy field',
-      town: 'Testington',
-      county: 'Testingshire',
-      postcode: 'AB1 2CD',
-      country: 'UK',
-      invoice_account_id: 'invoice_account_1',
-      invoice_account_number: 'A12345'
-    };
+    let row, result;
 
-    let result;
+    experiment('for a non-billing role', () => {
+      beforeEach(async () => {
+        row = createRow();
+        result = mappers.mapDocumentRole(row);
+      });
 
-    beforeEach(async () => {
-      result = mappers.mapDocumentRole(row);
-    });
+      test('object contains expected keys', async () => {
+        const keys = Object.keys(result);
+        expect(keys).to.only.include([
+          'documentRoleId',
+          'roleId',
+          'roleName',
+          'startDate',
+          'endDate',
+          'company',
+          'contact',
+          'address',
+          'invoiceAccount']);
+      });
 
-    test('object contains expected keys', async () => {
-      const keys = Object.keys(result);
-      expect(keys).to.only.include([
-        'documentRoleId',
-        'roleId',
-        'roleName',
-        'startDate',
-        'endDate',
-        'company',
-        'contact',
-        'address',
-        'invoiceAccount']);
-    });
+      test('document role is mapped correctly', async () => {
+        expect(result.documentRoleId).to.equal(row.document_role_id);
+        expect(result.roleId).to.equal(row.role_id);
+        expect(result.roleName).to.equal(row.role_name);
+        expect(result.startDate).to.equal(row.start_date);
+        expect(result.endDate).to.equal(row.end_date);
+      });
 
-    test('document role is mapped correctly', async () => {
-      expect(result.documentRoleId).to.equal(row.document_role_id);
-      expect(result.roleId).to.equal(row.role_id);
-      expect(result.roleName).to.equal(row.role_name);
-      expect(result.startDate).to.equal(row.start_date);
-      expect(result.endDate).to.equal(row.end_date);
-    });
+      test('company is mapped correctly', async () => {
+        expect(result.company).to.equal({
+          companyId: 'company_1',
+          name: 'company',
+          companyNumber: '12345'
+        });
+      });
 
-    test('company is mapped correctly', async () => {
-      expect(result.company).to.equal({
-        companyId: 'company_1',
-        name: 'company',
-        companyNumber: '12345'
+      test('contact is mapped correctly', async () => {
+        expect(result.contact).to.equal({
+          contactId: 'contact_1',
+          salutation: 'Dr',
+          firstName: 'John',
+          lastName: 'Doe',
+          middleNames: 'A'
+        });
+      });
+
+      test('address is mapped correctly', async () => {
+        expect(result.address).to.equal({
+          addressId: 'address_1',
+          address1: 'Daisy cottage',
+          address2: 'Buttercup lane',
+          address3: 'Dandelion road',
+          address4: 'Poppy field',
+          town: 'Testington',
+          county: 'Testingshire',
+          postcode: 'AB1 2CD',
+          country: 'UK'
+        });
+      });
+
+      test('invoice account is mapped correctly', async () => {
+        expect(result.invoiceAccount).to.equal({
+          invoiceAccountId: 'invoice_account_1',
+          invoiceAccountNumber: 'A12345'
+        });
       });
     });
 
-    test('contact is mapped correctly', async () => {
-      expect(result.contact).to.equal({
-        contactId: 'contact_1',
-        salutation: 'Dr',
-        firstName: 'John',
-        lastName: 'Doe',
-        middleNames: 'A'
+    experiment('for a billing role', () => {
+      beforeEach(async () => {
+        row = createRow('billing');
+        result = mappers.mapDocumentRole(row);
       });
-    });
 
-    test('address is mapped correctly', async () => {
-      expect(result.address).to.equal({
-        addressId: 'address_1',
-        address1: 'Daisy cottage',
-        address2: 'Buttercup lane',
-        address3: 'Dandelion road',
-        address4: 'Poppy field',
-        town: 'Testington',
-        county: 'Testingshire',
-        postcode: 'AB1 2CD',
-        country: 'UK'
-      });
-    });
-
-    test('invoice account is mapped correctly', async () => {
-      expect(result.invoiceAccount).to.equal({
-        invoiceAccountId: 'invoice_account_1',
-        invoiceAccountNumber: 'A12345'
+      test('the company is the invoice account company', async () => {
+        expect(result.company.companyId).to.equal(row.invoice_company_id);
+        expect(result.company.name).to.equal(row.invoice_company_name);
+        expect(result.company.companyNumber).to.equal(row.invoice_company_number);
       });
     });
   });


### PR DESCRIPTION
Previously, the company ID was set during import of billing roles on a document.
This is no longer the case, so the company ID is now null.
This PR fixes an issue where this was stopping billing roles from being retrieved in the v2 documents API.