### PR TITLE
Feat: Get contacts from the v2 crm

### DIFF
--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -5,6 +5,7 @@
     "node_modules",
     "test",
     "src/lib/logger/vendor/",
-    "src/routes"
+    "src/routes",
+    "src/v2/modules/*/routes.js"
   ]
 }

--- a/src/lib/camel-case-keys.js
+++ b/src/lib/camel-case-keys.js
@@ -1,0 +1,5 @@
+const { mapKeys, camelCase } = require('lodash');
+
+const camelCaseKeys = obj => mapKeys(obj, (value, key) => camelCase(key));
+
+module.exports = camelCaseKeys;

--- a/src/v2/connectors/repository/ContactsRepository.js
+++ b/src/v2/connectors/repository/ContactsRepository.js
@@ -1,0 +1,18 @@
+const queries = require('./queries/contacts');
+const Repository = require('./Repository');
+
+class ContactsRepository extends Repository {
+  /**
+   * Find a single contact record by its id
+   * @param {String} contactId - GUID
+   */
+  async findOneById (contactId) {
+    return this.findOne(queries.findOneById, [contactId]);
+  }
+
+  async findManyById (contactIds) {
+    return this.findMany(queries.findManyById, [contactIds]);
+  }
+}
+
+module.exports = ContactsRepository;

--- a/src/v2/connectors/repository/DocumentRolesRepository.js
+++ b/src/v2/connectors/repository/DocumentRolesRepository.js
@@ -1,16 +1,14 @@
-const { pool } = require('../../../lib/connectors/db');
 const queries = require('./queries/document-roles');
+const Repository = require('./Repository');
 
-class DocumentRolesRepository {
+class DocumentRolesRepository extends Repository {
   /**
    * Gets all document roles from DB for specified document
    * @param {String} documentId - GUID
    * @return {Promise<Array>}
    */
   async findByDocumentId (documentId) {
-    const params = [documentId];
-    const { rows } = await pool.query(queries.findByDocumentId, params);
-    return rows;
+    return this.findMany(queries.findByDocumentId, [documentId]);
   }
 }
 

--- a/src/v2/connectors/repository/DocumentsRepository.js
+++ b/src/v2/connectors/repository/DocumentsRepository.js
@@ -1,15 +1,13 @@
-const { pool } = require('../../../lib/connectors/db');
 const queries = require('./queries/documents');
+const Repository = require('./Repository');
 
-class DocumentsRepository {
+class DocumentsRepository extends Repository {
   /**
    * Find a single document record by its GUID
    * @param {String} documentId - GUID
    */
   async findOneById (documentId) {
-    const params = [documentId];
-    const { rows: [row] } = await pool.query(queries.findOneById, params);
-    return row;
+    return this.findOne(queries.findOneById, [documentId]);
   }
 
   /**
@@ -20,8 +18,7 @@ class DocumentsRepository {
    */
   async findByDocumentRef (regime, documentType, documentRef) {
     const params = [regime, documentType, documentRef];
-    const { rows } = await pool.query(queries.findByDocumentRef, params);
-    return rows;
+    return this.findMany(queries.findByDocumentRef, params);
   }
 }
 

--- a/src/v2/connectors/repository/Repository.js
+++ b/src/v2/connectors/repository/Repository.js
@@ -1,0 +1,27 @@
+const { pool } = require('../../../lib/connectors/db');
+
+class Repository {
+  /**
+   * Executes a query against the database and returns the first row
+   *
+   * @param {String} query Parameterised (or not) SQL query to execute
+   * @param {Array?} params Optional array of parameters
+   */
+  async findOne (query, params) {
+    const { rows: [row] } = await pool.query(query, params);
+    return row;
+  }
+
+  /**
+   * Executes a query against the database and returns all rows
+   *
+   * @param {String} query Parameterised (or not) SQL query to execute
+   * @param {Array?} params Optional array of parameters
+   */
+  async findMany (query, params) {
+    const { rows } = await pool.query(query, params);
+    return rows;
+  }
+}
+
+module.exports = Repository;

--- a/src/v2/connectors/repository/index.js
+++ b/src/v2/connectors/repository/index.js
@@ -1,5 +1,7 @@
 const DocumentsRepository = require('./DocumentsRepository');
 const DocumentRolesRepository = require('./DocumentRolesRepository');
+const ContactsRepository = require('./ContactsRepository');
 
+exports.contacts = new ContactsRepository();
 exports.documents = new DocumentsRepository();
 exports.documentRoles = new DocumentRolesRepository();

--- a/src/v2/connectors/repository/queries/contacts.js
+++ b/src/v2/connectors/repository/queries/contacts.js
@@ -1,0 +1,29 @@
+exports.findOneById = `
+  select
+    contact_id,
+    salutation,
+    initials,
+    first_name,
+    middle_names,
+    last_name,
+    external_id,
+    date_created,
+    date_updated
+  from crm_v2.contacts
+  where contact_id = $1;
+`;
+
+exports.findManyById = `
+  select
+    contact_id,
+    salutation,
+    initials,
+    first_name,
+    middle_names,
+    last_name,
+    external_id,
+    date_created,
+    date_updated
+  from crm_v2.contacts
+  where contact_id = any ($1);
+`;

--- a/src/v2/modules/contacts/controller.js
+++ b/src/v2/modules/contacts/controller.js
@@ -1,0 +1,18 @@
+const Boom = require('@hapi/boom');
+const camelCaseKeys = require('../../../lib/camel-case-keys');
+const repositories = require('../../connectors/repository');
+
+const getContact = async request => {
+  const { contactId } = request.params;
+  const contact = await repositories.contacts.findOneById(request.params.contactId);
+  return contact ? camelCaseKeys(contact) : Boom.notFound(`No contact for ${contactId}`);
+};
+
+const getContacts = async request => {
+  const { ids } = request.query;
+  const rows = await repositories.contacts.findManyById(ids.split(','));
+  return rows.map(camelCaseKeys);
+};
+
+exports.getContact = getContact;
+exports.getContacts = getContacts;

--- a/src/v2/modules/contacts/routes.js
+++ b/src/v2/modules/contacts/routes.js
@@ -1,0 +1,30 @@
+const Joi = require('@hapi/joi');
+const controller = require('./controller');
+
+exports.getContact = {
+  method: 'GET',
+  path: '/crm/2.0/contacts/{contactId}',
+  handler: controller.getContact,
+  options: {
+    description: 'Get a contact by id',
+    validate: {
+      params: {
+        contactId: Joi.string().guid().required()
+      }
+    }
+  }
+};
+
+exports.getDocuments = {
+  method: 'GET',
+  path: '/crm/2.0/contacts',
+  handler: controller.getContacts,
+  options: {
+    description: 'Get a list of contacts by id',
+    validate: {
+      query: {
+        ids: Joi.string().required()
+      }
+    }
+  }
+};

--- a/src/v2/modules/documents/controller.js
+++ b/src/v2/modules/documents/controller.js
@@ -1,12 +1,12 @@
 const Boom = require('@hapi/boom');
-
+const camelCaseKeys = require('../../../lib/camel-case-keys');
 const repositories = require('../../connectors/repository');
 const mappers = require('./lib/mappers');
 
 const getDocuments = async (request) => {
   const { regime, documentType, documentRef } = request.query;
   const data = await repositories.documents.findByDocumentRef(regime, documentType, documentRef);
-  return data.map(mappers.camelCaseKeys);
+  return data.map(camelCaseKeys);
 };
 
 const getDocument = async (request, h) => {
@@ -24,7 +24,7 @@ const getDocument = async (request, h) => {
 
   // Map data
   return {
-    ...mappers.camelCaseKeys(doc),
+    ...camelCaseKeys(doc),
     documentRoles: roles.map(mappers.mapDocumentRole)
   };
 };

--- a/src/v2/modules/documents/lib/mappers.js
+++ b/src/v2/modules/documents/lib/mappers.js
@@ -1,7 +1,5 @@
-const { mapKeys, pick } = require('lodash');
-const camelCase = require('camelcase');
-
-const camelCaseKeys = obj => mapKeys(obj, (value, key) => camelCase(key));
+const { mapKeys, pick, camelCase } = require('lodash');
+const camelCaseKeys = require('../../../../lib/camel-case-keys');
 
 const stripPrefix = (str, prefix) => camelCase(str.replace(prefix, ''));
 const stripKeyPrefix = (obj, prefix) =>
@@ -58,6 +56,5 @@ const mapDocumentRole = row => ({
   invoiceAccount: mapEntity(row, ['invoice_account_id', 'invoice_account_number'])
 });
 
-exports.camelCaseKeys = camelCaseKeys;
 exports.mapEntity = mapEntity;
 exports.mapDocumentRole = mapDocumentRole;

--- a/src/v2/routes.js
+++ b/src/v2/routes.js
@@ -1,3 +1,4 @@
 module.exports = [
+  ...Object.values(require('./modules/contacts/routes')),
   ...Object.values(require('./modules/documents/routes'))
 ];

--- a/test/lib/camel-case-keys.js
+++ b/test/lib/camel-case-keys.js
@@ -1,0 +1,20 @@
+const { experiment, test } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const camelCaseKeys = require('../../src/lib/camel-case-keys');
+
+experiment('lib/camelCaseKeys', () => {
+  test('converts object keys to camel case', async () => {
+    const obj = {
+      snake_case: 'foo',
+      camelCase: 'bar'
+    };
+
+    const result = camelCaseKeys(obj);
+
+    expect(result).to.equal({
+      snakeCase: 'foo',
+      camelCase: 'bar'
+    });
+  });
+});

--- a/test/v2/connectors/repository/ContactsRepository.js
+++ b/test/v2/connectors/repository/ContactsRepository.js
@@ -1,0 +1,95 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const ContactsRepository = require('../../../../src/v2/connectors/repository/ContactsRepository');
+const db = require('../../../../src/lib/connectors/db');
+const queries = require('../../../../src/v2/connectors/repository/queries/contacts');
+
+experiment('v2/connectors/repository/ContactsRepository', () => {
+  beforeEach(async () => {
+    sandbox.stub(db.pool, 'query').resolves();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.findOneById', () => {
+    let result;
+
+    beforeEach(async () => {
+      db.pool.query.resolves({
+        rows: [
+          { contact_id: 'test-contact-id' }
+        ]
+      });
+
+      const repo = new ContactsRepository();
+      result = await repo.findOneById('test-contact-id');
+    });
+
+    test('uses the expected query', async () => {
+      const [query] = db.pool.query.lastCall.args;
+      expect(query).to.equal(queries.findOneById);
+    });
+
+    test('passes the contact id as the query params', async () => {
+      const [, params] = db.pool.query.lastCall.args;
+      expect(params).to.equal(['test-contact-id']);
+    });
+
+    test('returns the row returned from the database', async () => {
+      expect(result).to.equal({
+        contact_id: 'test-contact-id'
+      });
+    });
+  });
+
+  experiment('.findManyById', () => {
+    let result;
+
+    beforeEach(async () => {
+      db.pool.query.resolves({
+        rows: [
+          { contact_id: 'test-contact-id-1' },
+          { contact_id: 'test-contact-id-2' }
+        ]
+      });
+
+      const repo = new ContactsRepository();
+      result = await repo.findManyById([
+        'test-contact-id-1',
+        'test-contact-id-2'
+      ]);
+    });
+
+    test('uses the expected query', async () => {
+      const [query] = db.pool.query.lastCall.args;
+      expect(query).to.equal(queries.findManyById);
+    });
+
+    test('passes the contact ids as the query params', async () => {
+      const [, params] = db.pool.query.lastCall.args;
+      expect(params).to.equal([
+        [
+          'test-contact-id-1',
+          'test-contact-id-2'
+        ]
+      ]);
+    });
+
+    test('returns the rows returned from the database', async () => {
+      expect(result).to.equal([
+        { contact_id: 'test-contact-id-1' },
+        { contact_id: 'test-contact-id-2' }
+      ]);
+    });
+  });
+});

--- a/test/v2/modules/contacts/controller.js
+++ b/test/v2/modules/contacts/controller.js
@@ -1,0 +1,108 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const controller = require('../../../../src/v2/modules/contacts/controller');
+const repositories = require('../../../../src/v2/connectors/repository');
+
+experiment('v2/modules/contacts/controller', () => {
+  beforeEach(async () => {
+    sandbox.stub(repositories.contacts, 'findOneById').resolves();
+    sandbox.stub(repositories.contacts, 'findManyById').resolves([]);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.getContact', () => {
+    experiment('when there is no contact found', () => {
+      test('a 404 response is returned', async () => {
+        repositories.contacts.findOneById.resolves(null);
+
+        const contactId = '00000000-0000-0000-0000-000000000000';
+        const request = { params: { contactId } };
+        const response = await controller.getContact(request);
+
+        expect(response.output.payload.message).to.equal(`No contact for ${contactId}`);
+        expect(response.output.payload.statusCode).to.equal(404);
+      });
+    });
+
+    experiment('when a contact is found', () => {
+      test('the object has its keys camel cased', async () => {
+        const contactId = '00000000-0000-0000-0000-000000000000';
+
+        repositories.contacts.findOneById.resolves({
+          contact_id: contactId
+        });
+
+        const request = { params: { contactId } };
+        const response = await controller.getContact(request);
+
+        expect(response).to.equal({ contactId });
+      });
+    });
+  });
+
+  experiment('.getContacts', () => {
+    test('passes the query ids to the repository as an array', async () => {
+      const request = {
+        query: {
+          ids: '00000000-0000-0000-0000-000000000000,11111111-0000-0000-0000-000000000000'
+        }
+      };
+
+      await controller.getContacts(request);
+      const [ids] = repositories.contacts.findManyById.lastCall.args;
+      expect(ids).to.equal([
+        '00000000-0000-0000-0000-000000000000',
+        '11111111-0000-0000-0000-000000000000'
+      ]);
+    });
+
+    experiment('when no contacts are found', () => {
+      test('an empty array is returned', async () => {
+        repositories.contacts.findManyById.resolves([]);
+
+        const request = {
+          query: {
+            ids: '00000000-0000-0000-0000-000000000000,11111111-0000-0000-0000-000000000000'
+          }
+        };
+
+        const response = await controller.getContacts(request);
+
+        expect(response).to.equal([]);
+      });
+    });
+
+    experiment('when a contacts are found', () => {
+      test('the objects have their keys camel cased', async () => {
+        repositories.contacts.findManyById.resolves([
+          { contact_id: '00000000-0000-0000-0000-000000000000' },
+          { contact_id: '00000000-0000-0000-0000-000000000001' }
+        ]);
+
+        const request = {
+          query: {
+            ids: '00000000-0000-0000-0000-000000000000,11111111-0000-0000-0000-000000000000'
+          }
+        };
+
+        const response = await controller.getContacts(request);
+
+        expect(response).to.equal([
+          { contactId: '00000000-0000-0000-0000-000000000000' },
+          { contactId: '00000000-0000-0000-0000-000000000001' }
+        ]);
+      });
+    });
+  });
+});

--- a/test/v2/modules/documents/lib/mappers.js
+++ b/test/v2/modules/documents/lib/mappers.js
@@ -57,20 +57,6 @@ const createBillingRowWithInvoiceAddress = () => createBillingRow({
 });
 
 experiment('v2/modules/documents/lib/mappers', () => {
-  experiment('camelCaseKeys', () => {
-    test('converts object keys to camel case', async () => {
-      const obj = {
-        snake_case: 'foo',
-        camelCase: 'bar'
-      };
-      const result = mappers.camelCaseKeys(obj);
-      expect(result).to.equal({
-        snakeCase: 'foo',
-        camelCase: 'bar'
-      });
-    });
-  });
-
   experiment('mapEntity', () => {
     const obj = {
       id: 1,


### PR DESCRIPTION
WATER-2445

Adds endpoints to get a single contact from the API or alternatively get
many contacts by passing a comma separated list of ids to the API.