### PR TITLE
Fix issue with colleagues endpoint (breaks share access flow)

### DIFF
--- a/src/lib/CRM.js
+++ b/src/lib/CRM.js
@@ -83,7 +83,7 @@ and
 
   return pool.query(query, queryParams)
     .then((res) => {
-      return res.data;
+      return res.rows;
     }).catch((err) => {
       logger.error('getColleagues error', err);
       return h.response(err);


### PR DESCRIPTION
Due to recent changes standardising the creation of the Postgres pool, query data is now accessed in { rows } rather than { data } as was the case with the old function.