### PR TITLE
Feat: Create and retrieve company endpoints

### DIFF
--- a/migrations/20200411131657-add-is-test-column.js
+++ b/migrations/20200411131657-add-is-test-column.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200411131657-add-is-test-column-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200411131657-add-is-test-column-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200411131657-add-is-test-column-down.sql
+++ b/migrations/sqls/20200411131657-add-is-test-column-down.sql
@@ -1,0 +1,26 @@
+alter table crm_v2.companies
+  drop column is_test;
+
+alter table crm_v2.addresses
+  drop column is_test;
+
+alter table crm_v2.company_addresses
+  drop column is_test;
+
+alter table crm_v2.contacts
+  drop column is_test;
+
+alter table crm_v2.company_contacts
+  drop column is_test;
+
+alter table crm_v2.documents
+  drop column is_test;
+
+alter table crm_v2.document_roles
+  drop column is_test;
+
+alter table crm_v2.invoice_accounts
+  drop column is_test;
+
+alter table crm_v2.invoice_account_addresses
+  drop column is_test;

--- a/migrations/sqls/20200411131657-add-is-test-column-up.sql
+++ b/migrations/sqls/20200411131657-add-is-test-column-up.sql
@@ -1,0 +1,26 @@
+alter table crm_v2.companies
+  add column is_test boolean not null default false;
+
+alter table crm_v2.addresses
+  add column is_test boolean not null default false;
+
+alter table crm_v2.company_addresses
+  add column is_test boolean not null default false;
+
+alter table crm_v2.contacts
+  add column is_test boolean not null default false;
+
+alter table crm_v2.company_contacts
+  add column is_test boolean not null default false;
+
+alter table crm_v2.documents
+  add column is_test boolean not null default false;
+
+alter table crm_v2.document_roles
+  add column is_test boolean not null default false;
+
+alter table crm_v2.invoice_accounts
+  add column is_test boolean not null default false;
+
+alter table crm_v2.invoice_account_addresses
+  add column is_test boolean not null default false;

--- a/src/v2/connectors/repository/companies.js
+++ b/src/v2/connectors/repository/companies.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { Company } = require('../bookshelf');
+
+/**
+ * Create a new person or company and saves in crm_v2.companies
+ *
+ * @param {Object} personOrCompany An object to persist to crm_v2.companies
+ * @returns {Object} The created company from the database
+ */
+const create = async personOrCompany => {
+  const model = await Company.forge(personOrCompany).save();
+  return model.toJSON();
+};
+
+/**
+ * Find single Company by ID
+ *
+ * @param {String} id
+ * @return {Promise<Object>}
+ */
+const findOne = async id => {
+  const result = await Company.forge({ companyId: id }).fetch();
+  return result ? result.toJSON() : null;
+};
+
+exports.create = create;
+exports.findOne = findOne;

--- a/src/v2/connectors/repository/index.js
+++ b/src/v2/connectors/repository/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const DocumentsRepository = require('./DocumentsRepository');
 const DocumentRolesRepository = require('./DocumentRolesRepository');
 const ContactsRepository = require('./ContactsRepository');
@@ -6,3 +8,4 @@ exports.contacts = new ContactsRepository();
 exports.documents = new DocumentsRepository();
 exports.documentRoles = new DocumentRolesRepository();
 exports.invoiceAccounts = require('./invoice-accounts');
+exports.companies = require('./companies');

--- a/src/v2/lib/company-types.js
+++ b/src/v2/lib/company-types.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.ORGANISATION = 'organisation';
+exports.PERSON = 'person';

--- a/src/v2/modules/companies/controller.js
+++ b/src/v2/modules/companies/controller.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const companiesService = require('../../services/companies');
+const companyTypes = require('../../lib/company-types');
+
+const postCompany = async (request, h) => {
+  const { type, name, companyNumber = null, isTest = false } = request.payload;
+
+  const createdEntity = type === companyTypes.PERSON
+    ? await companiesService.createPerson(name, isTest)
+    : await companiesService.createOrganisation(name, companyNumber, isTest);
+
+  return h.response(createdEntity)
+    .created(`/crm/2.0/companies/${createdEntity.companyId}`);
+};
+
+const getCompany = async request => {
+  const { companyId } = request.params;
+  const company = await companiesService.getCompany(companyId);
+  return company;
+};
+
+exports.getCompany = getCompany;
+exports.postCompany = postCompany;

--- a/src/v2/modules/companies/routes.js
+++ b/src/v2/modules/companies/routes.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Joi = require('@hapi/joi');
+
+const companyTypes = require('../../lib/company-types');
+const controller = require('./controller');
+
+exports.createCompany = {
+  method: 'POST',
+  path: '/crm/2.0/companies',
+  handler: controller.postCompany,
+  options: {
+    description: 'Creates a company entity',
+    validate: {
+      payload: {
+        name: Joi.string().required(),
+        type: Joi.string().valid(Object.values(companyTypes)).required(),
+        companyNumber: Joi.forbidden().when('type', {
+          is: companyTypes.ORGANISATION,
+          then: Joi.string().allow('').optional()
+        }),
+        isTest: Joi.boolean().optional().default(false)
+      }
+    }
+  }
+};
+
+exports.getCompany = {
+  method: 'GET',
+  path: '/crm/2.0/companies/{companyId}',
+  handler: controller.getCompany,
+  options: {
+    description: 'Get a company entity',
+    validate: {
+      params: {
+        companyId: Joi.string().uuid().required()
+      }
+    }
+  }
+};

--- a/src/v2/routes.js
+++ b/src/v2/routes.js
@@ -1,4 +1,5 @@
 module.exports = [
+  ...Object.values(require('./modules/companies/routes')),
   ...Object.values(require('./modules/contacts/routes')),
   ...Object.values(require('./modules/documents/routes')),
   ...Object.values(require('./modules/invoice-accounts/routes'))

--- a/src/v2/services/companies.js
+++ b/src/v2/services/companies.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const companyTypes = require('../lib/company-types');
+const repos = require('../connectors/repository');
+
+const createPerson = async (name, isTest = false) => {
+  const person = { name, type: companyTypes.PERSON, isTest };
+  const result = await repos.companies.create(person);
+  return result;
+};
+
+const createOrganisation = async (name, companyNumber = null, isTest = false) => {
+  const company = { name, companyNumber, type: companyTypes.ORGANISATION, isTest };
+  const result = await repos.companies.create(company);
+  return result;
+};
+
+const getCompany = async companyId => {
+  const result = await repos.companies.findOne(companyId);
+  return result;
+};
+
+exports.createPerson = createPerson;
+exports.createOrganisation = createOrganisation;
+exports.getCompany = getCompany;

--- a/test/v2/connectors/repository/companies.js
+++ b/test/v2/connectors/repository/companies.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const companiesRepo = require('../../../../src/v2/connectors/repository/companies');
+const Company = require('../../../../src/v2/connectors/bookshelf/Company');
+
+experiment('v2/connectors/repository/companies', () => {
+  let stub, model;
+
+  beforeEach(async () => {
+    model = {
+      toJSON: sandbox.stub().returns({ id: 'test-id' })
+    };
+
+    stub = {
+      save: sandbox.stub().resolves(model),
+      fetch: sandbox.stub().resolves(model)
+    };
+
+    sandbox.stub(Company, 'forge').returns(stub);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.create', () => {
+    let result;
+    let person;
+
+    beforeEach(async () => {
+      person = { type: 'person', name: 'test-name' };
+      result = await companiesRepo.create(person);
+    });
+
+    test('.forge() is called on the model with the data', async () => {
+      const [data] = Company.forge.lastCall.args;
+      expect(data).to.equal(person);
+    });
+
+    test('.save() is called after the forge', async () => {
+      expect(stub.save.called).to.equal(true);
+    });
+
+    test('the JSON representation is returned', async () => {
+      expect(model.toJSON.called).to.be.true();
+      expect(result.id).to.equal('test-id');
+    });
+  });
+
+  experiment('.findOne', () => {
+    let result;
+
+    experiment('when the id matches a company', () => {
+      beforeEach(async () => {
+        result = await companiesRepo.findOne('test-id');
+      });
+
+      test('.forge() is called on the model with the data', async () => {
+        const [data] = Company.forge.lastCall.args;
+        expect(data).to.equal({ companyId: 'test-id' });
+      });
+
+      test('.fetch() is called after the forge', async () => {
+        expect(stub.fetch.called).to.equal(true);
+      });
+
+      test('the JSON representation is returned', async () => {
+        expect(model.toJSON.called).to.be.true();
+        expect(result.id).to.equal('test-id');
+      });
+    });
+
+    experiment('when the id does not find a company', () => {
+      beforeEach(async () => {
+        stub.fetch.resolves();
+        result = await companiesRepo.findOne('test-id');
+      });
+
+      test('.forge() is called on the model with the data', async () => {
+        const [data] = Company.forge.lastCall.args;
+        expect(data).to.equal({ companyId: 'test-id' });
+      });
+
+      test('.fetch() is called after the forge', async () => {
+        expect(stub.fetch.called).to.equal(true);
+      });
+
+      test('null is returned', async () => {
+        expect(result).to.equal(null);
+      });
+    });
+  });
+});

--- a/test/v2/modules/companies/controller.js
+++ b/test/v2/modules/companies/controller.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+const uuid = require('uuid/v4');
+
+const controller = require('../../../../src/v2/modules/companies/controller');
+const companiesService = require('../../../../src/v2/services/companies');
+
+experiment('modules/companies/controller', () => {
+  let h;
+  let created;
+
+  beforeEach(async () => {
+    created = sandbox.spy();
+    h = {
+      response: sandbox.stub().returns({ created })
+    };
+
+    sandbox.stub(companiesService, 'getCompany');
+    sandbox.stub(companiesService, 'createPerson');
+    sandbox.stub(companiesService, 'createOrganisation');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.getCompany', () => {
+    let response;
+    let request;
+
+    beforeEach(async () => {
+      request = {
+        params: {
+          companyId: uuid()
+        }
+      };
+
+      companiesService.getCompany.resolves({
+        companyId: request.params.companyId,
+        name: 'test-company'
+      });
+
+      response = await controller.getCompany(request);
+    });
+
+    test('calls through to the service with the company id', async () => {
+      const [id] = companiesService.getCompany.lastCall.args;
+      expect(id).to.equal(request.params.companyId);
+    });
+
+    test('return the found data', async () => {
+      expect(response).to.equal({
+        companyId: request.params.companyId,
+        name: 'test-company'
+      });
+    });
+  });
+
+  experiment('.postCompany', () => {
+    beforeEach(async () => {
+      companiesService.createPerson.resolves({
+        companyId: 'test-person-id',
+        type: 'person'
+      });
+
+      companiesService.createOrganisation.resolves({
+        companyId: 'test-company-id',
+        type: 'organisation'
+      });
+    });
+
+    experiment('when creating a person', () => {
+      beforeEach(async () => {
+        await controller.postCompany({
+          payload: {
+            type: 'person',
+            name: 'test-name',
+            isTest: true
+          }
+        }, h);
+      });
+
+      test('calls the expected service function', async () => {
+        const [name, isTest] = companiesService.createPerson.lastCall.args;
+        expect(name).to.equal('test-name');
+        expect(isTest).to.equal(true);
+      });
+
+      test('returns the created entity in the response', async () => {
+        const [result] = h.response.lastCall.args;
+
+        expect(result).to.equal({
+          companyId: 'test-person-id',
+          type: 'person'
+        });
+      });
+
+      test('returns a 201 response code', async () => {
+        const [url] = created.lastCall.args;
+        expect(url).to.equal('/crm/2.0/companies/test-person-id');
+      });
+    });
+
+    experiment('when creating an organisation', () => {
+      beforeEach(async () => {
+        await controller.postCompany({
+          payload: {
+            type: 'organisation',
+            name: 'test-name',
+            companyNumber: '123abc',
+            isTest: true
+          }
+        }, h);
+      });
+
+      test('calls the expected service function', async () => {
+        const [name, companyNumber, isTest] = companiesService.createOrganisation.lastCall.args;
+        expect(name).to.equal('test-name');
+        expect(companyNumber).to.equal('123abc');
+        expect(isTest).to.equal(true);
+      });
+
+      test('returns the created entity in the response', async () => {
+        const [result] = h.response.lastCall.args;
+
+        expect(result).to.equal({
+          companyId: 'test-company-id',
+          type: 'organisation'
+        });
+      });
+
+      test('returns a 201 response code', async () => {
+        const [url] = created.lastCall.args;
+        expect(url).to.equal('/crm/2.0/companies/test-company-id');
+      });
+    });
+  });
+});

--- a/test/v2/modules/companies/routes.js
+++ b/test/v2/modules/companies/routes.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const Hapi = require('@hapi/hapi');
+const { cloneDeep } = require('lodash');
+
+const {
+  experiment,
+  test,
+  beforeEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const routes = require('../../../../src/v2/modules/companies/routes');
+
+const createServer = route => {
+  const server = Hapi.server();
+  const testRoute = cloneDeep(route);
+  testRoute.handler = async () => 'ok';
+
+  server.route(testRoute);
+
+  return server;
+};
+
+experiment('modules/companies/routes', () => {
+  experiment('getCompany', () => {
+    let server;
+
+    const getRequest = companyId => ({
+      method: 'GET',
+      url: `/crm/2.0/companies/${companyId}`
+    });
+
+    beforeEach(async () => {
+      server = createServer(routes.getCompany);
+    });
+
+    test('returns a 400 if the company id is not a uuid', async () => {
+      const request = getRequest(123);
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  experiment('createCompany', () => {
+    let server;
+
+    const getRequest = payload => ({
+      method: 'POST',
+      url: '/crm/2.0/companies',
+      payload
+    });
+
+    beforeEach(async () => {
+      server = createServer(routes.createCompany);
+    });
+
+    experiment('when a person is being created', () => {
+      test('isTest can be omitted', async () => {
+        const request = getRequest({
+          name: 'Timmy Test',
+          type: 'person'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.payload).to.equal('ok');
+        expect(response.statusCode).to.equal(200);
+      });
+
+      test('isTest must be boolean', async () => {
+        const request = getRequest({
+          name: 'Timmy Test',
+          type: 'person',
+          isTest: 'Sure is!'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.statusCode).to.equal(400);
+      });
+
+      test('the name must be supplied', async () => {
+        const request = getRequest({
+          type: 'person',
+          isTest: 'Sure is!'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.statusCode).to.equal(400);
+      });
+
+      test('the name must be a string', async () => {
+        const request = getRequest({
+          name: 123,
+          type: 'person'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.statusCode).to.equal(400);
+      });
+
+      test('cannot have a company number', async () => {
+        const request = getRequest({
+          name: 'Name',
+          type: 'person',
+          companyNumber: '123acb'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    experiment('when an organisation is being created', () => {
+      test('isTest can be omitted', async () => {
+        const request = getRequest({
+          name: 'Timmy Test',
+          type: 'organisation'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.payload).to.equal('ok');
+        expect(response.statusCode).to.equal(200);
+      });
+
+      test('isTest must be boolean', async () => {
+        const request = getRequest({
+          name: 'Timmy Test',
+          type: 'organisation',
+          isTest: 'Sure is!'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.statusCode).to.equal(400);
+      });
+
+      test('the name must be supplied', async () => {
+        const request = getRequest({
+          type: 'organisation'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.statusCode).to.equal(400);
+      });
+
+      test('the name must be a string', async () => {
+        const request = getRequest({
+          name: 123,
+          type: 'organisation'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.statusCode).to.equal(400);
+      });
+
+      test('can have a company number', async () => {
+        const request = getRequest({
+          name: 'Cash Inc',
+          type: 'organisation',
+          companyNumber: '123acb'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.statusCode).to.equal(200);
+      });
+
+      test('isTest defaults to false', async () => {
+        const request = getRequest({
+          name: 'Cash Inc',
+          type: 'organisation',
+          companyNumber: '123acb'
+        });
+
+        const response = await server.inject(request);
+
+        expect(response.request.payload.isTest).to.equal(false);
+      });
+    });
+  });
+});

--- a/test/v2/services/companies.js
+++ b/test/v2/services/companies.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const companiesService = require('../../../src/v2/services/companies');
+const repos = require('../../../src/v2/connectors/repository');
+
+experiment('services/companies', () => {
+  beforeEach(async () => {
+    sandbox.stub(repos.companies, 'create').resolves({
+      companyId: 'test-company-id'
+    });
+
+    sandbox.stub(repos.companies, 'findOne').resolves({
+      companyId: 'test-company-id'
+    });
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.createPerson', () => {
+    test('can create a test record', async () => {
+      await companiesService.createPerson('test-name', true);
+
+      const [person] = repos.companies.create.lastCall.args;
+      expect(person.name).to.equal('test-name');
+      expect(person.type).to.equal('person');
+      expect(person.isTest).to.equal(true);
+    });
+
+    test('creates a non test record by default', async () => {
+      await companiesService.createPerson('test-name');
+
+      const [person] = repos.companies.create.lastCall.args;
+      expect(person.name).to.equal('test-name');
+      expect(person.type).to.equal('person');
+      expect(person.isTest).to.equal(false);
+    });
+
+    test('returns the result from the datbase', async () => {
+      const result = await companiesService.createPerson('test-name');
+      expect(result.companyId).to.equal('test-company-id');
+    });
+  });
+
+  experiment('.createOrganisation', () => {
+    test('can create a test record', async () => {
+      await companiesService.createOrganisation('test-name', 'test-number', true);
+
+      const [organisation] = repos.companies.create.lastCall.args;
+      expect(organisation.name).to.equal('test-name');
+      expect(organisation.companyNumber).to.equal('test-number');
+      expect(organisation.type).to.equal('organisation');
+      expect(organisation.isTest).to.equal(true);
+    });
+
+    test('creates a non test record by default', async () => {
+      await companiesService.createOrganisation('test-name', 'test-number');
+
+      const [organisation] = repos.companies.create.lastCall.args;
+      expect(organisation.name).to.equal('test-name');
+      expect(organisation.type).to.equal('organisation');
+      expect(organisation.companyNumber).to.equal('test-number');
+      expect(organisation.isTest).to.equal(false);
+    });
+
+    test('creates a null company number by default', async () => {
+      await companiesService.createOrganisation('test-name');
+
+      const [organisation] = repos.companies.create.lastCall.args;
+      expect(organisation.name).to.equal('test-name');
+      expect(organisation.type).to.equal('organisation');
+      expect(organisation.companyNumber).to.equal(null);
+      expect(organisation.isTest).to.equal(false);
+    });
+
+    test('returns the result from the datbase', async () => {
+      const result = await companiesService.createOrganisation('test-name');
+      expect(result.companyId).to.equal('test-company-id');
+    });
+  });
+
+  experiment('.getCompany', async () => {
+    test('returns the data from the repository', async () => {
+      repos.companies.findOne.resolves({
+        type: 'person',
+        name: 'test-name',
+        companyId: 'test-id'
+      });
+
+      const company = await companiesService.getCompany('test-id');
+
+      expect(company).to.equal({
+        type: 'person',
+        name: 'test-name',
+        companyId: 'test-id'
+      });
+    });
+  });
+});


### PR DESCRIPTION
WATER-2631

Adds endpoints to allow a companies to be saved and to be retrieved.

Adds the is_test flag to all the database tables that will have test
data written to for acceptance testing