### PR TITLE
Feat/water 2710 invoice account api shape

### DIFF
--- a/src/v2/mappers/invoice-account.js
+++ b/src/v2/mappers/invoice-account.js
@@ -1,19 +1,16 @@
-const { find, omit, get } = require('lodash');
+// const { find, omit, get } = require('lodash');
+const moment = require('moment');
+const { sortBy } = require('lodash');
 
-const currentAddressOnly = invoiceAccount => {
-  const invoiceAccountAddress = find(invoiceAccount.invoiceAccountAddresses,
-    invoiceAccountAddress => invoiceAccountAddress.endDate === null
-  );
-  const address = get(invoiceAccountAddress, 'address', null);
-  const agentCompany = get(invoiceAccountAddress, 'agentCompany', null);
-  const contact = get(invoiceAccountAddress, 'contact', null);
+const getStartDateTimestamp = invoiceAccountAddress => moment(invoiceAccountAddress.startDate).unix();
+
+const mostRecentAddressOnly = invoiceAccount => {
+  const sortedAddresses = sortBy(invoiceAccount.invoiceAccountAddresses, getStartDateTimestamp);
 
   return {
-    ...omit(invoiceAccount, 'invoiceAccountAddresses'),
-    address,
-    agentCompany,
-    contact
+    ...invoiceAccount,
+    invoiceAccountAddresses: sortedAddresses.slice(-1)
   };
 };
 
-exports.currentAddressOnly = currentAddressOnly;
+exports.mostRecentAddressOnly = mostRecentAddressOnly;

--- a/src/v2/mappers/invoice-account.js
+++ b/src/v2/mappers/invoice-account.js
@@ -1,4 +1,3 @@
-// const { find, omit, get } = require('lodash');
 const moment = require('moment');
 const { sortBy } = require('lodash');
 

--- a/src/v2/services/invoice-accounts.js
+++ b/src/v2/services/invoice-accounts.js
@@ -24,7 +24,7 @@ const getInvoiceAccount = invoiceAccountId => invoiceAccountsRepo.findOne(invoic
 
 const getInvoiceAccountsByIds = async ids => {
   const results = await invoiceAccountsRepo.findWithCurrentAddress(ids);
-  return results.map(mappers.invoiceAccount.currentAddressOnly);
+  return results.map(mappers.invoiceAccount.mostRecentAddressOnly);
 };
 
 const ensureDateRangeDoesNotOverlapWithExistingAddress = async invoiceAccountAddress => {

--- a/test/v2/services/invoice-accounts.js
+++ b/test/v2/services/invoice-accounts.js
@@ -164,9 +164,13 @@ experiment('v2/services/invoice-accounts', () => {
       expect(result[1].company).to.equal(repositoryResponse[1].company);
     });
 
-    test('includes the current address only', async () => {
-      expect(result[0].address).to.equal(repositoryResponse[0].invoiceAccountAddresses[1].address);
-      expect(result[1].address).to.equal(repositoryResponse[1].invoiceAccountAddresses[1].address);
+    test('includes the most recent address only', async () => {
+      expect(result[0].invoiceAccountAddresses.length).to.equal(1);
+      expect(result[0].invoiceAccountAddresses[0].startDate).to.equal('2019-06-02');
+      expect(result[0].invoiceAccountAddresses[0].address).to.equal(repositoryResponse[0].invoiceAccountAddresses[1].address);
+      expect(result[1].invoiceAccountAddresses.length).to.equal(1);
+      expect(result[1].invoiceAccountAddresses[0].startDate).to.equal('2019-06-02');
+      expect(result[1].invoiceAccountAddresses[0].address).to.equal(repositoryResponse[1].invoiceAccountAddresses[1].address);
     });
   });
 


### PR DESCRIPTION
Modifies the response shape when getting multiple invoice accounts so that it is the same as when getting a single record.

This simplifies mapping code in the water service as it only has to deal with one response shape.

The most recent address is the only one returned to reduce the volume of data transferred.