### PR TITLE
Feat: Includes role in company contacts response

### DIFF
--- a/src/v2/connectors/bookshelf/CompanyContact.js
+++ b/src/v2/connectors/bookshelf/CompanyContact.js
@@ -10,7 +10,7 @@ module.exports = bookshelf.model('CompanyContact', {
   contact () {
     return this.hasOne('Contact', 'contact_id', 'contact_id');
   },
-  roles () {
-    return this.hasOne('Roles', 'role_id', 'role_id');
+  role () {
+    return this.hasOne('Role', 'role_id', 'role_id');
   }
 });

--- a/src/v2/connectors/bookshelf/Contact.js
+++ b/src/v2/connectors/bookshelf/Contact.js
@@ -6,8 +6,8 @@ module.exports = bookshelf.model('Contact', {
   tableName: 'contacts',
   idAttribute: 'contact_id',
   hasTimestamps: ['date_created', 'date_updated'],
+
   companyContacts () {
     return this.hasMany('CompanyContact', 'contact_id', 'contact_id');
   }
-
 });

--- a/src/v2/connectors/repository/company-contacts.js
+++ b/src/v2/connectors/repository/company-contacts.js
@@ -26,10 +26,9 @@ const findManyByCompanyId = async companyId => {
     .collection()
     .where('company_id', companyId)
     .fetch({
-      withRelated: [
-        'contact'
-      ]
+      withRelated: ['contact', 'role']
     });
+
   return collection.toJSON();
 };
 

--- a/test/v2/connectors/bookshelf/CompanyContact.js
+++ b/test/v2/connectors/bookshelf/CompanyContact.js
@@ -68,18 +68,18 @@ experiment('v2/connectors/bookshelf/CompanyContact', () => {
     });
   });
 
-  experiment('the .roles() relation', () => {
+  experiment('the .role() relation', () => {
     beforeEach(async () => {
-      instance.roles();
+      instance.role();
     });
 
     test('is a function', async () => {
-      expect(instance.roles).to.be.a.function();
+      expect(instance.role).to.be.a.function();
     });
 
     test('calls .hasOne with correct params', async () => {
       const [model, foreignKey, foreignKeyTarget] = instance.hasOne.lastCall.args;
-      expect(model).to.equal('Roles');
+      expect(model).to.equal('Role');
       expect(foreignKey).to.equal('role_id');
       expect(foreignKeyTarget).to.equal('role_id');
     });

--- a/test/v2/connectors/repository/company-contacts.js
+++ b/test/v2/connectors/repository/company-contacts.js
@@ -94,11 +94,9 @@ experiment('v2/connectors/repository/company-contacts', () => {
       )).to.be.true();
     });
 
-    test('.fetch() is callled with related contacts', async () => {
+    test('.fetch() is callled with related contact and role', async () => {
       expect(stub.fetch.calledWith({
-        withRelated: [
-          'contact'
-        ]
+        withRelated: ['contact', 'role']
       })).to.be.true();
     });
 


### PR DESCRIPTION
WATER-2721

Updates the companies/{id}/contacts response to include the name of the
role by joining the role table