### PR TITLE
Added a test to support water-2815

### DIFF
--- a/test/v2/modules/addresses/validator.js
+++ b/test/v2/modules/addresses/validator.js
@@ -262,7 +262,6 @@ experiment('modules/addresses/validator', () => {
       });
     });
 
-
     experiment('data_source', () => {
       test('can be omitted', async () => {
         const { error } = addressValidator.validate(fullAddress);
@@ -281,7 +280,5 @@ experiment('modules/addresses/validator', () => {
         expect(value.dataSource).to.equal('nald');
       });
     });
-
-
   });
 });

--- a/test/v2/modules/addresses/validator.js
+++ b/test/v2/modules/addresses/validator.js
@@ -261,5 +261,27 @@ experiment('modules/addresses/validator', () => {
         expect(error).to.not.equal(null);
       });
     });
+
+
+    experiment('data_source', () => {
+      test('can be omitted', async () => {
+        const { error } = addressValidator.validate(fullAddress);
+        expect(error).to.equal(null);
+      });
+
+      test('defaults to wrls', async () => {
+        const { value } = addressValidator.validate(fullAddress);
+        expect(value.dataSource).to.equal('wrls');
+      });
+
+      test('can be set', async () => {
+        fullAddress.dataSource = 'nald';
+        const { error, value } = addressValidator.validate(fullAddress);
+        expect(error).to.equal(null);
+        expect(value.dataSource).to.equal('nald');
+      });
+    });
+
+
   });
 });


### PR DESCRIPTION
Supports https://github.com/DEFRA/water-abstraction-import/pull/195

Not a necessary/urgent change. The purpose of adding this test is to prevent the issue from cropping up again in the future (regression?)