### PR TITLE
Fix: Allow soft deletion of documents

### DIFF
--- a/migrations/20201020083236-document-date-deleted.js
+++ b/migrations/20201020083236-document-date-deleted.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20201020083236-document-date-deleted-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20201020083236-document-date-deleted-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20201020083236-document-date-deleted-down.sql
+++ b/migrations/sqls/20201020083236-document-date-deleted-down.sql
@@ -1,0 +1,7 @@
+alter table crm.document_header
+  drop column date_created,
+  drop column date_updated,
+  drop column date_deleted;
+
+alter table crm_v2.documents
+  drop column date_deleted;

--- a/migrations/sqls/20201020083236-document-date-deleted-up.sql
+++ b/migrations/sqls/20201020083236-document-date-deleted-up.sql
@@ -1,0 +1,7 @@
+alter table crm.document_header
+  add column date_created timestamp without time zone not null default now(),
+  add column date_updated timestamp without time zone not null default now(),
+  add column date_deleted timestamp without time zone;
+
+alter table crm_v2.documents
+  add column date_deleted timestamp without time zone;

--- a/src/controllers/contacts.js
+++ b/src/controllers/contacts.js
@@ -259,6 +259,7 @@ function getCompanySqlQuery (filter) {
 async function getContacts (request, h) {
   try {
     const filter = JSON.parse(request.query.filter || '{}');
+    filter.date_deleted = null;
 
     // Do initial query to find documents and entities linked via roles
     const query = getMongoSqlQuery(filter);
@@ -303,7 +304,9 @@ const getDocumentsForContact = async (request, h) => {
     from crm.document_header dh
     inner join crm.document_entity de
     on dh.document_id = de.document_id
-    where de.entity_id = $1;`;
+    where de.entity_id = $1
+    and dh.date_deleted is null;
+  `;
 
   try {
     const { rows: documents } = await pool.query(sql, [entityId]);
@@ -314,7 +317,5 @@ const getDocumentsForContact = async (request, h) => {
   }
 };
 
-module.exports = {
-  getContacts,
-  getDocumentsForContact
-};
+exports.getContacts = getContacts;
+exports.getDocumentsForContact = getDocumentsForContact;

--- a/src/controllers/document-headers.js
+++ b/src/controllers/document-headers.js
@@ -90,6 +90,9 @@ async function getEntityFilter (mode, value, roles = null) {
 const getPreQueryFilter = async (result) => {
   const { string, email, roles, entity_id: entityId, includeExpired = false, ...filter } = result.filter;
 
+  // don't include soft deleted records
+  filter.date_deleted = null;
+
   // Only display current licences
   if (!includeExpired) {
     filter['metadata->>IsCurrent'] = { $ne: 'false' };

--- a/src/controllers/documents.js
+++ b/src/controllers/documents.js
@@ -9,6 +9,7 @@ const getDocumentUsersQuery = `
     inner join crm.entity_roles er on dh.company_entity_id = er.company_entity_id
     inner join crm.entity e on er.entity_id = e.entity_id
   where dh.document_id = $1
+  and dh.date_deleted is null
   and e.entity_type = 'individual';
 `;
 
@@ -42,6 +43,4 @@ const getDocumentUsers = async (request, h) => {
   }
 };
 
-module.exports = {
-  getDocumentUsers
-};
+exports.getDocumentUsers = getDocumentUsers;

--- a/src/controllers/verification-documents.js
+++ b/src/controllers/verification-documents.js
@@ -77,6 +77,7 @@ const getUserVerificationsQuery = `
       inner join crm.document_header dh
           on vd.document_id = dh.document_id
   where v.entity_id = $1
+  and dh.date_deleted is null
   and v.date_verified is null
   order by v.date_created;`;
 

--- a/src/v2/connectors/repository/documents.js
+++ b/src/v2/connectors/repository/documents.js
@@ -7,10 +7,18 @@ const raw = require('./lib/raw');
 
 /**
  * Find single Document by ID
- * @param {String} id
+ * @param {String} documentId
  * @return {Promise<Object>}
  */
-const findOne = async id => helpers.findOne(Document, 'documentId', id);
+const findOne = async documentId => {
+  const result = await Document
+    .forge({ documentId, dateDeleted: null })
+    .fetch({
+      require: false
+    });
+
+  return result && result.toJSON();
+};
 
 /**
    * Get all documents with a particular document reference in date/version order

--- a/src/v2/connectors/repository/queries/documents.js
+++ b/src/v2/connectors/repository/queries/documents.js
@@ -1,23 +1,33 @@
 exports.findOneById = `
-  select * from crm_v2.documents 
-  where document_id=$1
+  select *
+  from crm_v2.documents
+  where document_id = $1
+  and date_deleted is null;
 `;
 
 exports.findByDocumentRef = `
-  select * from crm_v2.documents
-  where regime=:regime and document_type=:documentType and document_ref=:documentRef
-  order by start_date, version_number, end_date
+  select *
+  from crm_v2.documents
+  where regime = :regime
+  and document_type = :documentType
+  and document_ref = :documentRef
+  and date_deleted is null
+  order by start_date, version_number, end_date;
 `;
 
 exports.findDocumentByRefAndDate = `
-  SELECT docs.*, docRoles.company_id, roles.role_id, roles.name AS role_name FROM crm_v2.documents docs
-  LEFT JOIN crm_v2.document_roles docRoles ON docRoles.document_id=docs.document_id AND company_id IS NOT NULL
-  JOIN crm_v2.roles roles ON roles.role_id = docRoles.role_id AND roles.name = 'licenceHolder' 
+  SELECT docs.*, docRoles.company_id, roles.role_id, roles.name AS role_name
+  FROM crm_v2.documents docs
+    LEFT JOIN crm_v2.document_roles docRoles
+      ON docRoles.document_id=docs.document_id AND company_id IS NOT NULL
+    JOIN crm_v2.roles roles
+      ON roles.role_id = docRoles.role_id AND roles.name = 'licenceHolder'
   WHERE regime=:regime
   AND document_type=:documentType
   AND document_ref=:documentRef
   AND docs.start_date<=:date
   AND (docs.end_date>=:date OR docs.end_date IS NULL)
+  AND docs.date_deleted is null
   ORDER BY docs.start_date, version_number, docs.end_date
   LIMIT 1;
 `;

--- a/test/v2/connectors/repository/documents.js
+++ b/test/v2/connectors/repository/documents.js
@@ -69,7 +69,10 @@ experiment('v2/connectors/repository/documents', () => {
 
       test('.forge() is called on the model with the data', async () => {
         const [data] = Document.forge.lastCall.args;
-        expect(data).to.equal({ documentId: 'test-id' });
+        expect(data).to.equal({
+          documentId: 'test-id',
+          dateDeleted: null
+        });
       });
 
       test('.fetch() is called after the forge', async () => {
@@ -90,7 +93,7 @@ experiment('v2/connectors/repository/documents', () => {
 
       test('.forge() is called on the model with the data', async () => {
         const [data] = Document.forge.lastCall.args;
-        expect(data).to.equal({ documentId: 'test-id' });
+        expect(data).to.equal({ documentId: 'test-id', dateDeleted: null });
       });
 
       test('.fetch() is called after the forge', async () => {


### PR DESCRIPTION
WATER-2882

Changes the documents tables to allow a date_deleted to be set which
will cause the soft delete of the document.

This is to facilitate an update to the licence import to allow
documents that have been deleted in NALD to be hidden from the search
results.