### PR TITLE
Handles unique constraint violation when inserting company

### DIFF
--- a/src/v2/connectors/repository/addresses.js
+++ b/src/v2/connectors/repository/addresses.js
@@ -37,7 +37,7 @@ const findOneWithCompanies = async id =>
 * @param {String} uprn
 * @return {Promise<Object>}
 */
-const findByUprn = async uprn => helpers.findMany(Address, { uprn });
+const findByUprn = uprn => helpers.findOne(Address, 'uprn', uprn);
 
 exports.findOne = findOne;
 exports.create = create;

--- a/src/v2/connectors/repository/addresses.js
+++ b/src/v2/connectors/repository/addresses.js
@@ -37,11 +37,11 @@ const findOneWithCompanies = async id =>
 * @param {String} uprn
 * @return {Promise<Object>}
 */
-const findByUprn = uprn => helpers.findOne(Address, 'uprn', uprn);
+const findOneByUprn = uprn => helpers.findOne(Address, 'uprn', uprn);
 
 exports.findOne = findOne;
 exports.create = create;
 exports.deleteOne = deleteOne;
 exports.deleteTestData = deleteTestData;
 exports.findOneWithCompanies = findOneWithCompanies;
-exports.findByUprn = findByUprn;
+exports.findOneByUprn = findOneByUprn;

--- a/src/v2/connectors/repository/companies.js
+++ b/src/v2/connectors/repository/companies.js
@@ -31,8 +31,17 @@ const deleteOne = async id => helpers.deleteOne(Company, 'companyId', id);
 
 const deleteTestData = async () => helpers.deleteTestData(Company);
 
+/**
+ * Find a single company by company number
+ *
+ * @param {String} companyNumber number name
+ * @return {Promise<Object>}
+ */
+const findOneByCompanyNumber = async companyNumber => helpers.findOne(Company, 'companyNumber', companyNumber);
+
 exports.create = create;
 exports.deleteTestData = deleteTestData;
 exports.findOne = findOne;
 exports.deleteOne = deleteOne;
 exports.findAllByName = findAllByName;
+exports.findOneByCompanyNumber = findOneByCompanyNumber;

--- a/src/v2/connectors/repository/company-addresses.js
+++ b/src/v2/connectors/repository/company-addresses.js
@@ -36,7 +36,15 @@ const findManyByCompanyId = async companyId => {
   return collection.toJSON();
 };
 
+const findOneByCompanyAddressAndRoleId = (companyId, addressId, roleId) =>
+  helpers.findOneBy(CompanyAddress, {
+    companyId,
+    addressId,
+    roleId
+  });
+
 exports.create = create;
 exports.deleteOne = deleteOne;
 exports.deleteTestData = deleteTestData;
 exports.findManyByCompanyId = findManyByCompanyId;
+exports.findOneByCompanyAddressAndRoleId = findOneByCompanyAddressAndRoleId;

--- a/src/v2/connectors/repository/helpers.js
+++ b/src/v2/connectors/repository/helpers.js
@@ -1,9 +1,9 @@
 'use strict';
 const { snakeCase } = require('lodash');
 
-exports.findOne = async (bookshelfModel, idKey, id, withRelated = []) => {
+const findOneBy = async (bookshelfModel, query = {}, withRelated = []) => {
   const result = await bookshelfModel
-    .forge({ [idKey]: id })
+    .forge(query)
     .fetch({
       withRelated,
       require: false
@@ -11,6 +11,9 @@ exports.findOne = async (bookshelfModel, idKey, id, withRelated = []) => {
 
   return result && result.toJSON();
 };
+
+exports.findOne = async (bookshelfModel, idKey, id, withRelated = []) =>
+  findOneBy(bookshelfModel, { [idKey]: id }, withRelated);
 
 exports.findAll = async (bookshelfModel, idKey, id) => {
   const result = await bookshelfModel
@@ -46,3 +49,5 @@ exports.deleteTestData = async (bookShelfModel) => {
     require: false
   });
 };
+
+exports.findOneBy = findOneBy;

--- a/src/v2/lib/errors.js
+++ b/src/v2/lib/errors.js
@@ -8,9 +8,10 @@ class DBError extends Error {
 }
 
 class UniqueConstraintViolation extends DBError {
-  constructor (message) {
+  constructor (message, existingEntity) {
     super(message);
     this.name = 'UniqueConstraintViolation';
+    this.existingEntity = existingEntity;
   }
 }
 

--- a/src/v2/lib/map-error-response.js
+++ b/src/v2/lib/map-error-response.js
@@ -8,7 +8,12 @@ const transformEntityValidationError = error => {
   return boomError;
 };
 
-const transformConflict = error => Boom.conflict(error.message);
+const transformConflict = error => {
+  const boomError = Boom.conflict(error.message);
+  boomError.output.payload.existingEntity = error.existingEntity;
+  return boomError;
+};
+
 const transformNotFound = error => Boom.notFound(error.message);
 
 const commandMap = new Map();

--- a/src/v2/lib/pg-error.js
+++ b/src/v2/lib/pg-error.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Checks if the PG error is a constraint error
+ *
+ * @param {Error} err - the PG error
+ * @param {String} constraint - the constraint name
+ * @return {Boolean}
+ */
+const isConstraintViolationError = (err, constraint) =>
+  err.code === '23505' && err.constraint === constraint;
+
+exports.isConstraintViolationError = isConstraintViolationError;

--- a/src/v2/lib/wrap-service-call.js
+++ b/src/v2/lib/wrap-service-call.js
@@ -1,8 +1,25 @@
+'use strict';
+const pluralize = require('pluralize');
 const { mapErrorResponse } = require('./map-error-response');
 
-const wrapServiceCall = (service, method, mapRequest) => async request => {
+const isPost = request => request.method.toLowerCase() === 'post';
+
+const getEntityName = method => method.replace('create', '').toLowerCase();
+
+const getIdProperty = method => `${getEntityName(method)}Id`;
+
+const wrapServiceCall = (service, method, mapRequest) => async (request, h) => {
   try {
     const data = await service[method](...mapRequest(request));
+
+    if (isPost(request)) {
+      const entityName = getEntityName(method);
+      const idProperty = getIdProperty(method);
+      const path = `/crm/2.0/${pluralize(entityName)}/${data[idProperty]}`;
+      return h.response(data)
+        .created(path);
+    }
+
     return data;
   } catch (err) {
     return mapErrorResponse(err);

--- a/src/v2/modules/addresses/controller.js
+++ b/src/v2/modules/addresses/controller.js
@@ -1,25 +1,6 @@
+'use strict';
+
 const addressService = require('../../services/address');
+const { wrapServiceCall } = require('../../lib/wrap-service-call');
 
-const getExistingEntity = async uprn =>
-  addressService.getAddressByUprn(uprn);
-
-const getExistingEntityErrorResponse = async address => {
-  const { uprn } = address;
-  const existingEntity = await getExistingEntity(uprn);
-  return {
-    existingEntity,
-    error: `An address with UPRN of ${uprn} already exists`
-  };
-};
-
-const postAddress = async (request, h) => {
-  const { payload: address } = request;
-  const { address: createdAddress, error } = await addressService.createAddress(address);
-  if (error) {
-    const errorResponse = await getExistingEntityErrorResponse(address);
-    return h.response(errorResponse).code(409);
-  }
-  return h.response(createdAddress).created(`/crm/2.0/addresses/${createdAddress.addressId}`);
-};
-
-exports.postAddress = postAddress;
+exports.postAddress = wrapServiceCall(addressService, 'createAddress', request => [request.payload]);

--- a/src/v2/modules/companies/controller.js
+++ b/src/v2/modules/companies/controller.js
@@ -8,12 +8,16 @@ const { wrapServiceCall } = require('../../lib/wrap-service-call');
 const postCompany = async (request, h) => {
   const { type, name, companyNumber = null, organisationType = null, isTest = false } = request.payload;
 
-  const createdEntity = type === companyTypes.PERSON
-    ? await companiesService.createPerson(name, isTest)
-    : await companiesService.createOrganisation(name, companyNumber, organisationType, isTest);
+  try {
+    const createdEntity = type === companyTypes.PERSON
+      ? await companiesService.createPerson(name, isTest)
+      : await companiesService.createOrganisation(name, companyNumber, organisationType, isTest);
 
-  return h.response(createdEntity)
-    .created(`/crm/2.0/companies/${createdEntity.companyId}`);
+    return h.response(createdEntity)
+      .created(`/crm/2.0/companies/${createdEntity.companyId}`);
+  } catch (err) {
+    return mapErrorResponse(err);
+  }
 };
 
 const getCompany = async request => {

--- a/src/v2/services/address.js
+++ b/src/v2/services/address.js
@@ -37,7 +37,7 @@ const createAddress = async address => {
   } catch (err) {
     // unique violation
     if (isConstraintViolationError(err, 'unique_address_uprn')) {
-      const existingEntity = await getAddressByUprn(address.uprn);
+      const existingEntity = await addressRepo.findByUprn(address.uprn);
       throw new UniqueConstraintViolation(`An address with UPRN ${address.uprn} already exists`, existingEntity);
     }
     throw err;
@@ -48,12 +48,6 @@ const getAddress = addressId => addressRepo.findOne(addressId);
 
 const deleteAddress = addressId => addressRepo.deleteOne(addressId);
 
-const getAddressByUprn = async uprn => {
-  const [address] = await addressRepo.findByUprn(uprn);
-  return address;
-};
-
 exports.createAddress = createAddress;
 exports.getAddress = getAddress;
 exports.deleteAddress = deleteAddress;
-exports.getAddressByUprn = getAddressByUprn;

--- a/src/v2/services/address.js
+++ b/src/v2/services/address.js
@@ -33,7 +33,7 @@ const createAddress = async address => {
 
   try {
     const createdAddress = await addressRepo.create(mapValidatedAddress(validatedAddress));
-    return { address: createdAddress };
+    return createdAddress;
   } catch (err) {
     // unique violation
     if (isConstraintViolationError(err, 'unique_address_uprn')) {

--- a/src/v2/services/address.js
+++ b/src/v2/services/address.js
@@ -32,8 +32,7 @@ const createAddress = async address => {
   }
 
   try {
-    const createdAddress = await addressRepo.create(mapValidatedAddress(validatedAddress));
-    return createdAddress;
+    return await addressRepo.create(mapValidatedAddress(validatedAddress));
   } catch (err) {
     // unique violation
     if (isConstraintViolationError(err, 'unique_address_uprn')) {

--- a/src/v2/services/address.js
+++ b/src/v2/services/address.js
@@ -36,7 +36,7 @@ const createAddress = async address => {
   } catch (err) {
     // unique violation
     if (isConstraintViolationError(err, 'unique_address_uprn')) {
-      const existingEntity = await addressRepo.findByUprn(address.uprn);
+      const existingEntity = await addressRepo.findOneByUprn(address.uprn);
       throw new UniqueConstraintViolation(`An address with UPRN ${address.uprn} already exists`, existingEntity);
     }
     throw err;

--- a/src/v2/services/companies.js
+++ b/src/v2/services/companies.js
@@ -27,7 +27,7 @@ const createOrganisation = async (name, companyNumber = null, organisationType =
     // unique violation
     if (isConstraintViolationError(err, 'company_number')) {
       const existingEntity = await repos.companies.findOneByCompanyNumber(companyNumber);
-      throw new errors.UniqueConstraintViolation(`An company with number ${companyNumber} already exists`, existingEntity);
+      throw new errors.UniqueConstraintViolation(`A company with number ${companyNumber} already exists`, existingEntity);
     }
     throw err;
   }

--- a/test/v2/connectors/repository/addresses.js
+++ b/test/v2/connectors/repository/addresses.js
@@ -109,9 +109,9 @@ experiment('v2/connectors/repository/addresses', () => {
     });
   });
 
-  experiment('.findByUprn', () => {
+  experiment('.findOneByUprn', () => {
     beforeEach(async () => {
-      await addressesRepo.findByUprn(123456);
+      await addressesRepo.findOneByUprn(123456);
     });
 
     test('uses the .findOne helper', async () => {

--- a/test/v2/connectors/repository/addresses.js
+++ b/test/v2/connectors/repository/addresses.js
@@ -32,6 +32,7 @@ experiment('v2/connectors/repository/addresses', () => {
     sandbox.stub(Address, 'forge').returns(stub);
     sandbox.stub(repoHelpers, 'deleteTestData');
     sandbox.stub(repoHelpers, 'deleteOne');
+    sandbox.stub(repoHelpers, 'findOne');
   });
 
   afterEach(async () => {
@@ -63,46 +64,14 @@ experiment('v2/connectors/repository/addresses', () => {
   });
 
   experiment('.findOne', () => {
-    let result;
-
-    experiment('when the id matches an address', () => {
-      beforeEach(async () => {
-        result = await addressesRepo.findOne('test-id');
-      });
-
-      test('.forge() is called on the model with the data', async () => {
-        const [data] = Address.forge.lastCall.args;
-        expect(data).to.equal({ addressId: 'test-id' });
-      });
-
-      test('.fetch() is called after the forge', async () => {
-        expect(stub.fetch.called).to.equal(true);
-      });
-
-      test('the JSON representation is returned', async () => {
-        expect(model.toJSON.called).to.be.true();
-        expect(result.id).to.equal('test-id');
-      });
+    beforeEach(async () => {
+      await addressesRepo.findOne('test-id');
     });
 
-    experiment('when the id does not find an address', () => {
-      beforeEach(async () => {
-        stub.fetch.resolves(null);
-        result = await addressesRepo.findOne('test-id');
-      });
-
-      test('.forge() is called on the model with the data', async () => {
-        const [data] = Address.forge.lastCall.args;
-        expect(data).to.equal({ addressId: 'test-id' });
-      });
-
-      test('.fetch() is called after the forge', async () => {
-        expect(stub.fetch.called).to.equal(true);
-      });
-
-      test('null is returned', async () => {
-        expect(result).to.equal(null);
-      });
+    test('uses the .findOne helper', async () => {
+      expect(repoHelpers.findOne.calledWith(
+        Address, 'addressId', 'test-id'
+      )).to.be.true();
     });
   });
 
@@ -128,12 +97,10 @@ experiment('v2/connectors/repository/addresses', () => {
 
   experiment('.findOneWithCompanies', () => {
     beforeEach(async () => {
-      sandbox.stub(repoHelpers, 'findOne');
+      await addressesRepo.findOneWithCompanies('test-id');
     });
 
     test('is created using the helpers', async () => {
-      await addressesRepo.findOneWithCompanies('test-id');
-
       const [model, field, id, related] = repoHelpers.findOne.lastCall.args;
       expect(model).to.equal(Address);
       expect(field).to.equal('addressId');
@@ -143,28 +110,14 @@ experiment('v2/connectors/repository/addresses', () => {
   });
 
   experiment('.findByUprn', () => {
-    let result;
-
     beforeEach(async () => {
-      result = await addressesRepo.findByUprn(123456);
+      await addressesRepo.findByUprn(123456);
     });
 
-    test('.forge() is called on the model with the data', async () => {
-      expect(Address.forge.called).to.be.true();
-    });
-
-    test('.where() is called with the expected conditions', async () => {
-      const [conditions] = stub.where.lastCall.args;
-      expect(conditions).to.equal({ uprn: 123456 });
-    });
-
-    test('.fetchAll() is called after the forge', async () => {
-      expect(stub.fetchAll.called).to.be.true();
-    });
-
-    test('the JSON representation is returned', async () => {
-      expect(model.toJSON.called).to.be.true();
-      expect(result.id).to.equal('test-id');
+    test('uses the .findOne helper', async () => {
+      expect(repoHelpers.findOne.calledWith(
+        Address, 'uprn', 123456
+      )).to.be.true();
     });
   });
 });

--- a/test/v2/connectors/repository/companies.js
+++ b/test/v2/connectors/repository/companies.js
@@ -30,6 +30,7 @@ experiment('v2/connectors/repository/companies', () => {
     sandbox.stub(Company, 'forge').returns(stub);
     sandbox.stub(repoHelpers, 'deleteTestData');
     sandbox.stub(repoHelpers, 'deleteOne');
+    sandbox.stub(repoHelpers, 'findOne');
   });
 
   afterEach(async () => {
@@ -61,46 +62,15 @@ experiment('v2/connectors/repository/companies', () => {
   });
 
   experiment('.findOne', () => {
-    let result;
-
-    experiment('when the id matches a company', () => {
-      beforeEach(async () => {
-        result = await companiesRepo.findOne('test-id');
-      });
-
-      test('.forge() is called on the model with the data', async () => {
-        const [data] = Company.forge.lastCall.args;
-        expect(data).to.equal({ companyId: 'test-id' });
-      });
-
-      test('.fetch() is called after the forge', async () => {
-        expect(stub.fetch.called).to.equal(true);
-      });
-
-      test('the JSON representation is returned', async () => {
-        expect(model.toJSON.called).to.be.true();
-        expect(result.id).to.equal('test-id');
-      });
+    const ID = 'test-id';
+    beforeEach(async () => {
+      await companiesRepo.findOne(ID);
     });
 
-    experiment('when the id does not find a company', () => {
-      beforeEach(async () => {
-        stub.fetch.resolves(null);
-        result = await companiesRepo.findOne('test-id');
-      });
-
-      test('.forge() is called on the model with the data', async () => {
-        const [data] = Company.forge.lastCall.args;
-        expect(data).to.equal({ companyId: 'test-id' });
-      });
-
-      test('.fetch() is called after the forge', async () => {
-        expect(stub.fetch.called).to.equal(true);
-      });
-
-      test('null is returned', async () => {
-        expect(result).to.equal(null);
-      });
+    test('uses the .findOne repo helper', async () => {
+      expect(repoHelpers.findOne.calledWith(
+        Company, 'companyId', ID
+      )).to.be.true();
     });
   });
 
@@ -141,6 +111,20 @@ experiment('v2/connectors/repository/companies', () => {
 
       const [model] = repoHelpers.deleteTestData.lastCall.args;
       expect(model).to.equal(Company);
+    });
+  });
+
+  experiment('.findOneByCompanyNumber', () => {
+    const COMPANY_NUMBER = 'test-company-number';
+
+    beforeEach(async () => {
+      await companiesRepo.findOneByCompanyNumber(COMPANY_NUMBER);
+    });
+
+    test('uses the .findOne repo helper', async () => {
+      expect(repoHelpers.findOne.calledWith(
+        Company, 'companyNumber', COMPANY_NUMBER)
+      ).to.be.true();
     });
   });
 });

--- a/test/v2/connectors/repository/company-addresses.js
+++ b/test/v2/connectors/repository/company-addresses.js
@@ -33,6 +33,7 @@ experiment('v2/connectors/repository/company-addresses', () => {
 
     sandbox.stub(repoHelpers, 'deleteTestData');
     sandbox.stub(repoHelpers, 'deleteOne');
+    sandbox.stub(repoHelpers, 'findOneBy');
   });
 
   afterEach(async () => {
@@ -117,6 +118,27 @@ experiment('v2/connectors/repository/company-addresses', () => {
 
     test('the JSON representation is returned', async () => {
       expect(model.toJSON.called).to.be.true();
+    });
+  });
+
+  experiment('.findOneByCompanyAddressAndRoleId', () => {
+    const companyId = 'company-id';
+    const addressId = 'address-id';
+    const roleId = 'role-id';
+
+    beforeEach(async () => {
+      await companyAddressesRepo.findOneByCompanyAddressAndRoleId(companyId, addressId, roleId);
+    });
+
+    test('delegates to .findOneBy() repo helper', async () => {
+      expect(repoHelpers.findOneBy.calledWith(
+        CompanyAddress,
+        {
+          companyId,
+          addressId,
+          roleId
+        }
+      )).to.be.true();
     });
   });
 });

--- a/test/v2/modules/addresses/controller.js
+++ b/test/v2/modules/addresses/controller.js
@@ -11,6 +11,7 @@ const { omit } = require('lodash');
 
 const controller = require('../../../../src/v2/modules/addresses/controller');
 const addressService = require('../../../../src/v2/services/address');
+const { UniqueConstraintViolation } = require('../../../../src/v2/lib/errors');
 
 const addressData = {
   addressId: 'test-address-id',
@@ -37,7 +38,6 @@ experiment('v2/modules/addresses/controller', () => {
     };
 
     sandbox.stub(addressService, 'createAddress');
-    sandbox.stub(addressService, 'getAddressByUprn').resolves(addressData);
   });
 
   afterEach(async () => {
@@ -49,9 +49,9 @@ experiment('v2/modules/addresses/controller', () => {
     experiment('when the address is created without issue', () => {
       beforeEach(async () => {
         payload = omit(addressData, 'addressId');
-        const request = { payload };
+        const request = { payload, method: 'post' };
 
-        addressService.createAddress.resolves({ address: addressData });
+        addressService.createAddress.resolves(addressData);
         await controller.postAddress(request, h);
       });
 
@@ -74,33 +74,31 @@ experiment('v2/modules/addresses/controller', () => {
     });
 
     experiment('when a record with that uprn already exists', () => {
+      const ERROR = new UniqueConstraintViolation('Message', addressData);
+      let result;
+
       beforeEach(async () => {
         payload = omit(addressData, 'id');
-        const request = { payload };
+        const request = { payload, method: 'post' };
 
-        addressService.createAddress.resolves({ error: 'oh no!' });
-        await controller.postAddress(request, h);
+        addressService.createAddress.rejects(ERROR);
+        result = await controller.postAddress(request, h);
       });
 
-      test('the existing entity is fetched', () => {
-        expect(addressService.getAddressByUprn.calledWith(
-          123456
-        )).to.be.true();
+      test('the response is a Boom error', async () => {
+        expect(result.isBoom).to.be.true();
       });
 
-      test('the response header contains the existing entity', async () => {
-        const [{ existingEntity }] = h.response.lastCall.args;
-        expect(existingEntity).to.equal(addressData);
+      test('the response contains the existing entity', async () => {
+        expect(result.output.payload.existingEntity).to.equal(addressData);
       });
 
       test('the response header contains the expected error message', async () => {
-        const [{ error }] = h.response.lastCall.args;
-        expect(error).to.equal('An address with UPRN of 123456 already exists');
+        expect(result.message).to.equal(ERROR.message);
       });
 
-      test('the 409 conflict code is returned', async () => {
-        const [code] = responseStub.code.lastCall.args;
-        expect(code).to.equal(409);
+      test('the Boom error has a 409 conflict status code', async () => {
+        expect(result.output.statusCode).to.equal(409);
       });
     });
   });

--- a/test/v2/modules/companies/controller.js
+++ b/test/v2/modules/companies/controller.js
@@ -184,6 +184,27 @@ experiment('modules/companies/controller', () => {
         expect(url).to.equal('/crm/2.0/companies/test-company-id');
       });
     });
+
+    experiment('when there is an error', () => {
+      let response;
+      const ERROR = new errors.EntityValidationError('oops!');
+
+      beforeEach(async () => {
+        companiesService.createPerson.rejects(ERROR);
+        response = await controller.postCompany({
+          payload: {
+            type: 'person',
+            name: 'test-name',
+            isTest: true
+          }
+        }, h);
+      });
+
+      test('the error is mapped', async () => {
+        expect(response.isBoom).to.be.true();
+        expect(response.output.statusCode).to.equal(422);
+      });
+    });
   });
 
   experiment('.postCompanyAddress', () => {

--- a/test/v2/modules/companies/controller.js
+++ b/test/v2/modules/companies/controller.js
@@ -361,6 +361,7 @@ experiment('modules/companies/controller', () => {
   experiment('.getCompanyAddresses', () => {
     let result;
     const request = {
+      method: 'get',
       params: {
         companyId: 'test-company-id'
       }
@@ -401,6 +402,7 @@ experiment('modules/companies/controller', () => {
   experiment('.getCompanyContacts', () => {
     let result;
     const request = {
+      method: 'get',
       params: {
         companyId: 'test-company-id'
       }

--- a/test/v2/services/address.js
+++ b/test/v2/services/address.js
@@ -19,7 +19,7 @@ experiment('v2/services/address', () => {
     sandbox.stub(addressRepo, 'create').resolves();
     sandbox.stub(addressRepo, 'findOne').resolves();
     sandbox.stub(addressRepo, 'deleteOne').resolves();
-    sandbox.stub(addressRepo, 'findByUprn').resolves();
+    sandbox.stub(addressRepo, 'findOneByUprn').resolves();
   });
 
   afterEach(async () => {
@@ -85,7 +85,7 @@ experiment('v2/services/address', () => {
         error.constraint = 'unique_address_uprn';
         error.detail = 'unique constraint violation on uprn';
         addressRepo.create.throws(error);
-        addressRepo.findByUprn.resolves({
+        addressRepo.findOneByUprn.resolves({
           addressId: 'test-address-id'
         });
       });


### PR DESCRIPTION
* Responds with 409 code and existing entity if attempting to create company with same company number
* Implements a pattern where the UniqueConstraintValidation error is thrown and mapped 
* Modifies the 'create address' endpoint to use the same pattern
* Responds with 409 code and existing entity if attempting to create company address which conflicts with existing company ID / address ID / role ID combination