### PR TITLE
fix: billing contact account name

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/DEFRA/water-abstraction-tactical-crm"
   },
   "scripts": {
+    "dev": "cd \"$(dirname \"$0\")\" || exit && export $(grep -v '^#' ../water-abstraction-orchestration/secrets/.env | xargs) && export $(grep -v '^#' ../water-abstraction-orchestration/services/variables.env | xargs) && nodemon . ",
     "test": "lab",
     "test:bail": "lab --bail",
     "test:ci": "lab -t 55 -m 0 --coverage-path ./src/ -r lcov -o coverage/lcov.info -r console -o stdout",

--- a/src/v2/connectors/bookshelf/Company.js
+++ b/src/v2/connectors/bookshelf/Company.js
@@ -12,5 +12,8 @@ module.exports = bookshelf.model('Company', {
 
   invoiceAccounts () {
     return this.hasMany('InvoiceAccount', 'company_id', 'company_id');
+  },
+  companyContact () {
+    return this.hasMany('CompanyContact', 'company_id', 'company_id');
   }
 });

--- a/src/v2/connectors/repository/invoice-accounts.js
+++ b/src/v2/connectors/repository/invoice-accounts.js
@@ -76,6 +76,9 @@ const findWithCurrentAddress = async ids => {
     .fetch({
       withRelated: [
         'company',
+        'company.companyContact',
+        'company.companyContact.contact',
+        'company.companyContact.role',
         {
           invoiceAccountAddresses: qb => qb
             .where('end_date', null)

--- a/test/v2/connectors/repository/invoice-accounts.js
+++ b/test/v2/connectors/repository/invoice-accounts.js
@@ -142,7 +142,7 @@ experiment('v2/connectors/repository/invoice-account', () => {
         expect(values).to.equal(invoiceAccountIds);
       });
 
-      test.only('.fetch() called with correct related models', async () => {
+      test('.fetch() called with correct related models', async () => {
         const { withRelated } = stub.fetch.lastCall.args[0];
         expect(withRelated).to.include('company');
         expect(withRelated).to.include('company.companyContact');
@@ -153,7 +153,7 @@ experiment('v2/connectors/repository/invoice-account', () => {
         expect(withRelated[4].invoiceAccountAddresses).to.be.a.function();
       });
 
-      test.only('.invoiceAccountAddresses selected are current - when end date is null', async () => {
+      test('.invoiceAccountAddresses selected are current - when end date is null', async () => {
         const qbStub = {
           where: sandbox.stub()
         };

--- a/test/v2/connectors/repository/invoice-accounts.js
+++ b/test/v2/connectors/repository/invoice-accounts.js
@@ -142,18 +142,22 @@ experiment('v2/connectors/repository/invoice-account', () => {
         expect(values).to.equal(invoiceAccountIds);
       });
 
-      test('.fetch() called with correct related models', async () => {
+      test.only('.fetch() called with correct related models', async () => {
         const { withRelated } = stub.fetch.lastCall.args[0];
         expect(withRelated).to.include('company');
-        expect(withRelated[1].invoiceAccountAddresses).to.be.a.function();
+        expect(withRelated).to.include('company.companyContact');
+        expect(withRelated).to.include('company.companyContact.role');
         expect(withRelated).to.include('invoiceAccountAddresses.address');
+        expect(withRelated).to.include('invoiceAccountAddresses.agentCompany');
+        expect(withRelated).to.include('invoiceAccountAddresses.contact');
+        expect(withRelated[4].invoiceAccountAddresses).to.be.a.function();
       });
 
-      test('.invoiceAccountAddresses selected are current - when end date is null', async () => {
+      test.only('.invoiceAccountAddresses selected are current - when end date is null', async () => {
         const qbStub = {
           where: sandbox.stub()
         };
-        const { invoiceAccountAddresses } = stub.fetch.lastCall.args[0].withRelated[1];
+        const { invoiceAccountAddresses } = stub.fetch.lastCall.args[0].withRelated[4];
         invoiceAccountAddresses(qbStub);
         expect(qbStub.where.calledWith(
           'end_date', null


### PR DESCRIPTION
WATER 3644

Theres are multiple names associated with companies this work will introduce a new flow to determine what name to show (just an if else in the UI )

```
if invoice.faoContact 
elif invoice.billingContact.agentCompanyName 
elif invoice.billingContact.roleContact.licenceHolder
elif invoice.billingContact.roleContact.billing
else invoice.name
```
