### PR TITLE
Set log level using new env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ ERRBIT_KEY=
 ERRBIT_SERVER=
 
 NODE_ENV=local
+
+# Set log level for app. Default is 'info'
+WRLS_LOG_LEVEL=debug

--- a/config.js
+++ b/config.js
@@ -1,14 +1,13 @@
 'use strict'
 require('dotenv').config()
 
-const testMode = parseInt(process.env.TEST_MODE) === 1
 const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
 
 module.exports = {
   version: '1.0',
 
   logger: {
-    level: testMode ? 'info' : 'error',
+    level: process.env.WRLS_LOG_LEVEL || 'info',
     airbrakeKey: process.env.ERRBIT_KEY,
     airbrakeHost: process.env.ERRBIT_SERVER,
     airbrakeLevel: 'error'


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/41

We're currently unable to set the log level used within the app. Instead, it's determined by looking at the env var `TEST_MODE`. If 'truthy' it sets the log level to `info`, else the default is `error`.

But we'd actually like to run with `debug` locally and `info` in **production**. And if that works out too noisy perhaps try `warn`. The key thing is we would expect to be able to explicitly set the log level for an app in an environment and currently we can't.

So, this change removes the reliance on `TEST_MODE` for setting the log level and instead will read it directly from an env var (if set).