### PR TITLE
Correctly set NODE_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ DATABASE_URL=
 ERRBIT_KEY=
 ERRBIT_SERVER=
 
-NODE_ENV=local
+NODE_ENV=production
+ENVIRONMENT=pre
 
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 'use strict'
-require('dotenv').config()
 
-const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
+const environment = process.env.ENVIRONMENT
+const isProduction = environment === 'prd'
 
 module.exports = {
   version: '1.0',
@@ -35,5 +35,5 @@ module.exports = {
     max: process.env.NODE_ENV === 'local' ? 20 : 7
   },
 
-  isAcceptanceTestTarget
+  isProduction
 }

--- a/config.js
+++ b/config.js
@@ -32,7 +32,7 @@ module.exports = {
 
   pg: {
     connectionString: process.env.DATABASE_URL,
-    max: process.env.NODE_ENV === 'local' ? 20 : 7
+    max: 7
   },
 
   isProduction

--- a/src/controllers/acceptance-tests.js
+++ b/src/controllers/acceptance-tests.js
@@ -51,7 +51,7 @@ const deleteAcceptanceTestCompanies = async (request, h) => {
   return h.response().code(204)
 }
 
-if (config.isAcceptanceTestTarget) {
+if (!config.isProduction) {
   exports.deleteAcceptanceTestDataDocuments = deleteAcceptanceTestDataDocuments
   exports.deleteAcceptanceTestDataEntities = deleteAcceptanceTestDataEntities
   exports.deleteAcceptanceTestCompanies = deleteAcceptanceTestCompanies

--- a/src/routes/acceptance-tests.js
+++ b/src/routes/acceptance-tests.js
@@ -2,7 +2,7 @@ const { version } = require('../../config')
 const controller = require('../controllers/acceptance-tests')
 const config = require('../../config')
 
-if (config.isAcceptanceTestTarget) {
+if (!config.isProduction) {
   exports.acceptanceTestTearDownDocuments = {
     method: 'DELETE',
     path: `/crm/${version}/acceptance-tests/documents`,

--- a/src/v2/modules/test-data/routes.js
+++ b/src/v2/modules/test-data/routes.js
@@ -3,7 +3,7 @@
 const controller = require('./controller')
 const config = require('../../../../config')
 
-if (config.isAcceptanceTestTarget) {
+if (!config.isProduction) {
   exports.deleteTestData = {
     method: 'DELETE',
     path: '/crm/2.0/test-data',


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/43

We are currently using `NODE_ENV` incorrectly; we set it to be the name of the specific environment (eg. `local`, `qa` etc.) when it should be more like the _type_ of environment (e.g. is it a dev environment, a production environment, etc.)

This means that tools like pm2 aren't correctly picking up that we are running in a dev-like or prod-like environment and configuring accordingly.

We, therefore, change how we use `NODE_ENV` to be the type of environment, with a separate `ENVIRONMENT` env var to set the actual environment (eg. `tst`, `pre` etc.)