### PR TITLE
Create `/health/info` endpoint

### DIFF
--- a/src/modules/health/controller.js
+++ b/src/modules/health/controller.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// We use promisify to wrap exec in a promise. This allows us to await it without resorting to using callbacks.
+const util = require('util')
+const exec = util.promisify(require('child_process').exec)
+
+const pkg = require('../../../package.json')
+
+const _getCommitHash = async () => {
+  try {
+    const { stdout, stderr } = await exec('git rev-parse HEAD')
+    return stderr ? `ERROR: ${stderr}` : stdout.replace('\n', '')
+  } catch (error) {
+    return `ERROR: ${error.message}`
+  }
+}
+
+const getInfo = async () => {
+  return {
+    version: pkg.version,
+    commit: await _getCommitHash()
+  }
+}
+
+exports.getInfo = getInfo

--- a/src/modules/health/routes.js
+++ b/src/modules/health/routes.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const controller = require('./controller')
+
+module.exports = {
+  getInfo: {
+    method: 'GET',
+    path: '/health/info',
+    handler: controller.getInfo,
+    config: {
+      auth: false
+    }
+  }
+}

--- a/src/routes/crm.js
+++ b/src/routes/crm.js
@@ -7,6 +7,7 @@ const Joi = require('joi')
 
 const documentsRoutes = Object.values(require('./documents'))
 const acceptanceTestRoutes = require('../routes/acceptance-tests')
+const healthRoutes = require('../modules/health/routes')
 const KPIReportingRoutes = require('../modules/kpi-reporting/routes')
 
 const EntityApi = require('../controllers/entities.js')
@@ -188,5 +189,6 @@ module.exports = [
   KpiApi.findManyRoute(),
   ...Object.values(KPIReportingRoutes),
   ...Object.values(documentsRoutes),
-  ...Object.values(acceptanceTestRoutes)
+  ...Object.values(acceptanceTestRoutes),
+  ...Object.values(healthRoutes)
 ]

--- a/test/modules/health/controller.test.js
+++ b/test/modules/health/controller.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+// Test framework dependencies
+const { test, experiment, before } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+
+// Test helpers
+const pkg = require('../../../package.json')
+
+// Thing under test
+const controller = require('../../../src/modules/health/controller')
+
+experiment('modules/health/controller', () => {
+  experiment('.getInfo', () => {
+    let info
+
+    before(async () => {
+      info = await controller.getInfo()
+    })
+
+    test('contains the expected water service version', async () => {
+      expect(info.version).to.equal(pkg.version)
+    })
+
+    test('contains the git commit hash', async () => {
+      expect(info.commit).to.exist()
+    })
+  })
+})


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-system/pull/8

We create a new endpoint `/health/info` which will be used by our System repo to display info. Currently this will be this repo's version and current git commit hash.