### PR TITLE
Stop passing err to logger.error

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// TODO: Figure out why we need this for the tests to pass!
+require('dotenv').config()
+
 const environment = process.env.ENVIRONMENT
 const isProduction = environment === 'prd'
 

--- a/index.js
+++ b/index.js
@@ -80,12 +80,12 @@ async function start () {
       server.log('info', `Service ${name} running at: ${uri}`)
     }
   } catch (err) {
-    logger.error('Failed to start server', err)
+    logger.error('Failed to start server', err.stack)
   }
 }
 
 const processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 

--- a/src/controllers/contacts.js
+++ b/src/controllers/contacts.js
@@ -292,7 +292,7 @@ async function getContacts (request, h) {
       data: mapRowsToEntities([...rows, ...rows2, ...rows3])
     }
   } catch (error) {
-    logger.error('getContacts error', error, { filter: request.query.filter })
+    logger.error('getContacts error', error.stack, { filter: request.query.filter })
     return h.response({ error, data: null }).code(500)
   }
 }
@@ -312,7 +312,7 @@ const getDocumentsForContact = async (request, h) => {
     const { rows: documents } = await pool.query(sql, [entityId])
     return documents
   } catch (error) {
-    logger.error('getDocumentsForContact error', error)
+    logger.error('getDocumentsForContact error', error.stack)
     throw error
   }
 }

--- a/src/controllers/documents.js
+++ b/src/controllers/documents.js
@@ -38,7 +38,7 @@ const getDocumentUsers = async (request, h) => {
     return { data, error: null }
   } catch (error) {
     const msg = 'Error getting document users'
-    logger.error(msg, error)
+    logger.error(msg, error.stack)
     return Boom.badImplementation(msg, error)
   }
 }

--- a/src/controllers/verification-documents.js
+++ b/src/controllers/verification-documents.js
@@ -26,7 +26,7 @@ async function postVerificationDocuments (request, h) {
     const { rows: data } = await pool.query(query, params)
     return { error: null, data }
   } catch (error) {
-    logger.error('postVerificationDocuments error', error)
+    logger.error('postVerificationDocuments error', error.stack)
     h.response({ error, data: null }).code(500)
   }
 }
@@ -45,7 +45,7 @@ async function getVerificationDocuments (request, h) {
     const { rows: data } = await pool.query(query, params)
     return { error: null, data }
   } catch (error) {
-    logger.error('getVerificationDocuments error', error)
+    logger.error('getVerificationDocuments error', error.stack)
     h.response({ error, data: null }).code(500)
   }
 }
@@ -58,7 +58,7 @@ const deleteVerificationDocuments = async (request, h) => {
     await pool.query(query, params)
     return h.response().code(204)
   } catch (error) {
-    logger.error('getVerificationDocuments error', error)
+    logger.error('getVerificationDocuments error', error.stack)
     h.response({ error, data: null }).code(500)
   }
 }
@@ -113,7 +113,7 @@ const getUserVerifications = async (request, h) => {
 
     return { data, error: null }
   } catch (error) {
-    logger.error('getVerificationDocuments error', error)
+    logger.error('getVerificationDocuments error', error.stack)
     h.response({ error, data: null }).code(500)
   }
 }

--- a/src/controllers/verifications-by-document.js
+++ b/src/controllers/verifications-by-document.js
@@ -50,7 +50,7 @@ async function getVerificationsByDocumentID (request, h) {
 
     return { error, data: rows }
   } catch (error) {
-    logger.error('getVerificationsByDocumentID error', error)
+    logger.error('getVerificationsByDocumentID error', error.stack)
     h.response({ error, data: null }).statusCode(500)
   }
 }

--- a/src/lib/CRM.js
+++ b/src/lib/CRM.js
@@ -67,7 +67,7 @@ and granter_role.entity_id = $1 `
     .then((res) => {
       return res.rows
     }).catch((err) => {
-      logger.error('getColleagues error', err)
+      logger.error('getColleagues error', err.stack)
       return h.response(err)
     })
 }

--- a/src/v2/modules/contacts/controller.js
+++ b/src/v2/modules/contacts/controller.js
@@ -9,7 +9,7 @@ const getContacts = async request => {
   try {
     return contactService.getContactsByIds(request.query.ids)
   } catch (err) {
-    logger.error('Could not get contacts', err)
+    logger.error('Could not get contacts', err.stack)
     return Boom.boomify(err)
   }
 }

--- a/src/v2/modules/invoice-accounts/controller.js
+++ b/src/v2/modules/invoice-accounts/controller.js
@@ -9,7 +9,7 @@ const getInvoiceAccounts = async request => {
   try {
     return invoiceAccountService.getInvoiceAccountsByIds(request.query.id)
   } catch (err) {
-    logger.error('Could not get invoice accounts', err)
+    logger.error('Could not get invoice accounts', err.stack)
     return Boom.boomify(err)
   }
 }
@@ -18,7 +18,7 @@ const getInvoiceAccountsWithRecentlyUpdatedEntities = async () => {
   try {
     return invoiceAccountService.getInvoiceAccountsWithRecentlyUpdatedEntities()
   } catch (err) {
-    logger.error('Could not get recently updated invoice accounts', err)
+    logger.error('Could not get recently updated invoice accounts', err.stack)
     return Boom.boomify(err)
   }
 }
@@ -28,7 +28,7 @@ const getInvoiceAccountByRef = async request => {
     const { ref } = request.query
     return invoiceAccountService.getInvoiceAccountByRef(ref)
   } catch (err) {
-    logger.error('Could not get invoice account', err)
+    logger.error('Could not get invoice account', err.stack)
     return Boom.boomify(err)
   }
 }
@@ -42,7 +42,7 @@ const updateInvoiceAccountsWithCustomerFileReference = async (request, h) => {
       error: null
     }).code(202)
   } catch (err) {
-    logger.error('Could not update invoice accounts', err)
+    logger.error('Could not update invoice accounts', err.stack)
     return Boom.boomify(err)
   }
 }

--- a/src/v2/modules/roles/controller.js
+++ b/src/v2/modules/roles/controller.js
@@ -15,7 +15,7 @@ const getRoleByName = async request => {
     }
     return role
   } catch (err) {
-    logger.error('Error getting role', err)
+    logger.error('Error getting role', err.stack)
     return Boom.boomify(err)
   }
 }

--- a/test/controllers/contacts.test.js
+++ b/test/controllers/contacts.test.js
@@ -50,7 +50,7 @@ experiment('controllers/contacts', () => {
     test('the error is logged', async () => {
       const [msg, err, params] = logger.error.lastCall.args
       expect(msg).to.equal('getContacts error')
-      expect(err).to.equal(error)
+      expect(err).to.equal(error.stack)
       expect(params).to.equal({
         filter: null
       })

--- a/test/controllers/documents.test.js
+++ b/test/controllers/documents.test.js
@@ -76,13 +76,14 @@ experiment('getDocumentUsers', () => {
   })
 
   test('logs any unexpected error', async () => {
-    sandbox.stub(pool, 'query').rejects({ name: 'error' })
+    const err = new Error('oops')
+    sandbox.stub(pool, 'query').rejects(err)
     const request = { params: { documentId: '00000000-0000-0000-0000-000000000000' } }
     const response = await controller.getDocumentUsers(request)
 
     const [message, error] = logger.error.lastCall.args
     expect(message).to.equal('Error getting document users')
-    expect(error.name).to.equal('error')
+    expect(error).to.equal(err.stack)
 
     expect(response.output.statusCode).to.equal(500)
   })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/45

Here we are trying to make the error logs more usable. Currently when an error happens the logs are getting jammed up with thousands of lines making them difficult to read and unusable. This change stops that pollution making them more usable.