### PR TITLE
Remove hapi good - add hapi-pino

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,12 +26,6 @@ module.exports = {
     airbrakeLevel: 'error'
   },
 
-  good: {
-    ops: {
-      interval: 10000
-    }
-  },
-
   server: {
     router: {
       stripTrailingSlash: true

--- a/config.js
+++ b/config.js
@@ -9,6 +9,16 @@ const isProduction = environment === 'prd'
 module.exports = {
   version: '1.0',
 
+  // This config is specifically for hapi-pino which was added to replace the deprecated (and noisy!) hapi/good. At
+  // some point all logging would go through this. But for now, it just covers requests & responses
+  log: {
+    // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
+    // converting the env var to a boolean
+    logInTest: (String(process.env.LOG_IN_TEST) === 'true') || false
+  },
+
+  // This config is used by water-abstraction-helpers and its use of Winston and Airbrake. Any use of `logger.info()`,
+  // for example, is built on this config.
   logger: {
     level: process.env.WRLS_LOG_LEVEL || 'info',
     airbrakeKey: process.env.ERRBIT_KEY,

--- a/index.js
+++ b/index.js
@@ -2,19 +2,14 @@
 
 require('dotenv').config()
 
-const GoodWinston = require('good-winston')
+const Blipp = require('blipp')
 const Hapi = require('@hapi/hapi')
+const HapiAuthJwt2 = require('hapi-auth-jwt2')
 
 const config = require('./config')
 const db = require('./src/lib/connectors/db')
+const HapiPinoPlugin = require('./src/plugins/hapi-pino.plugin.js')
 const { logger } = require('./src/logger')
-const goodWinstonStream = new GoodWinston({ winston: logger })
-
-const serverPlugins = {
-  blipp: require('blipp'),
-  hapiAuthJwt2: require('hapi-auth-jwt2'),
-  good: require('@hapi/good')
-}
 
 const server = new Hapi.Server(config.server)
 
@@ -30,25 +25,6 @@ function validateJWT (decoded, request, h) {
   return { isValid }
 }
 
-const initGood = async () => {
-  await server.register({
-    plugin: serverPlugins.good,
-    options: {
-      ...config.good,
-      reporters: {
-        winston: [goodWinstonStream]
-      }
-    }
-  })
-}
-
-const initBlipp = async () => {
-  await server.register({
-    plugin: serverPlugins.blipp,
-    options: config.blipp
-  })
-}
-
 const configureJwtStrategy = () => {
   server.auth.strategy('jwt', 'jwt', {
     key: process.env.JWT_SECRET, // Never Share your secret key
@@ -62,10 +38,15 @@ const configureJwtStrategy = () => {
 
 async function start () {
   try {
-    await initGood()
-    await initBlipp()
+    await server.register(HapiPinoPlugin())
 
-    await server.register({ plugin: serverPlugins.hapiAuthJwt2 })
+    await server.register({
+      plugin: Blipp,
+      options: config.blipp
+    })
+
+    // JWT token auth
+    await server.register(HapiAuthJwt2)
 
     configureJwtStrategy()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@envage/hapi-pg-rest-api": "^7.0.0",
         "@envage/water-abstraction-helpers": "4.8.3",
         "@hapi/boom": "^10.0.0",
-        "@hapi/good": "^9.0.1",
         "@hapi/hapi": "^21.0.0",
         "@joi/date": "^2.1.0",
         "blipp": "^4.0.2",
@@ -22,8 +21,8 @@
         "db-migrate-pg": "^1.2.2",
         "deep-map-keys": "^2.0.1",
         "dotenv": "^16.0.3",
-        "good-winston": "^4.0.0",
         "hapi-auth-jwt2": "^10.2.0",
+        "hapi-pino": "^11.0.1",
         "joi": "^17.7.0",
         "knex": "^0.21.21",
         "moment": "^2.29.4",
@@ -39,6 +38,7 @@
       "devDependencies": {
         "@hapi/code": "^9.0.1",
         "@hapi/lab": "^25.0.1",
+        "pino-pretty": "^9.1.1",
         "sinon": "^14.0.2",
         "standard": "^17.0.0"
       }
@@ -729,17 +729,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
       "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
-    "node_modules/@hapi/good": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/good/-/good-9.0.1.tgz",
-      "integrity": "sha512-zHSjw+LieqDgu5pXLUHqUJTMSgBKIdKHwxmXNoh9qVz+kSPQH463ol6OEBSTVdy0yQawKVI4eAyeqown++TpbA==",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/oppsy": "3.x.x",
-        "@hapi/validate": "1.x.x",
-        "pumpify": "2.x.x"
-      }
-    },
     "node_modules/@hapi/hapi": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.1.0.tgz",
@@ -925,14 +914,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
       "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
-    },
-    "node_modules/@hapi/oppsy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/oppsy/-/oppsy-3.0.0.tgz",
-      "integrity": "sha512-0kfUEAqIi21GzFVK2snMO07znMEBiXb+/pOx1dmgOO9TuvFstcfmHU5i56aDfiFP2DM5WzQCU2UWc2gK1lMDhQ==",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x"
-      }
     },
     "node_modules/@hapi/pez": {
       "version": "6.0.0",
@@ -1325,11 +1306,135 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
+    "node_modules/@types/hapi__catbox": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
+      "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg=="
+    },
+    "node_modules/@types/hapi__hapi": {
+      "version": "20.0.13",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.13.tgz",
+      "integrity": "sha512-LP4IPfhIO5ZPVOrJo7H8c8Slc0WYTFAUNQX1U0LBPKyXioXhH5H2TawIgxKujIyOhbwoBbpvOsBf6o5+ToJIrQ==",
+      "dependencies": {
+        "@hapi/boom": "^9.0.0",
+        "@hapi/iron": "^6.0.0",
+        "@hapi/podium": "^4.1.3",
+        "@types/hapi__catbox": "*",
+        "@types/hapi__mimos": "*",
+        "@types/hapi__shot": "*",
+        "@types/node": "*",
+        "joi": "^17.3.0"
+      }
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/b64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/bourne": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/cryptiles": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/iron": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "dependencies": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/podium": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@types/hapi__hapi/node_modules/@hapi/teamwork": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@types/hapi__mimos": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
+      "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
+      "dependencies": {
+        "@types/mime-db": "*"
+      }
+    },
+    "node_modules/@types/hapi__shot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
+      "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/mime-db": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
+      "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ=="
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.12.tgz",
+      "integrity": "sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg=="
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -1553,6 +1658,14 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1598,6 +1711,25 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1755,6 +1887,29 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2170,6 +2325,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/db-migrate": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/db-migrate/-/db-migrate-0.11.13.tgz",
@@ -2394,17 +2558,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "node_modules/easy-table": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
@@ -2448,6 +2601,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3317,6 +3471,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -3547,6 +3717,12 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
+      "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3577,6 +3753,20 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "node_modules/fastq": {
@@ -4093,16 +4283,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/good-winston": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/good-winston/-/good-winston-4.0.0.tgz",
-      "integrity": "sha512-ensNvhqlXsm0D1xY4o+TwBSJL/AZGHH7dlxLFMIeicJ7a6B80Ld15XEkFFXNoRHjAgkXm2d7otjgzExiwAASCw==",
-      "dependencies": {
-        "hoek": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "moment": "^2.18.1"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -4165,6 +4345,23 @@
       "dependencies": {
         "@hapi/hoek": "9.x.x"
       }
+    },
+    "node_modules/hapi-pino": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-11.0.1.tgz",
+      "integrity": "sha512-H09Cwh9pjpGJOBopswqszX5K5pygOke+5Wo25TCjG1MqTqDy7zzwFKkVHrY8IhsTdy99lewxBrOWsCMrcN8zPg==",
+      "dependencies": {
+        "@hapi/hoek": "^10.0.0",
+        "@types/hapi__hapi": "^20.0.10",
+        "abstract-logging": "^2.0.1",
+        "get-caller-file": "^2.0.5",
+        "pino": "^8.5.0"
+      }
+    },
+    "node_modules/hapi-pino/node_modules/@hapi/hoek": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+      "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
@@ -4311,13 +4508,68 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+    "node_modules/help-me": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.1.0.tgz",
+      "integrity": "sha512-5HMrkOks2j8Fpu2j5nTLhrBhT7VwHwELpqnSnx802ckofys5MO2SkLpgSz3dgNFHV7IYFX2igm5CM75SmuYidw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/help-me/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/help-me/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/help-me/node_modules/minimatch": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/help-me/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -4344,6 +4596,25 @@
         "node": ">=0.8",
         "npm": ">=1.3.7"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/immutability-helper": {
       "version": "3.1.1",
@@ -4396,7 +4667,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -4782,6 +5054,15 @@
         "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-sdsl": {
@@ -5678,10 +5959,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5996,6 +6283,72 @@
         "node": ">=6"
       }
     },
+    "node_modules/pino": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.7.0.tgz",
+      "integrity": "sha512-l9sA5uPxmZzwydhMWUcm1gI0YxNnYl8MfSr2h8cwLvOAzQLBLewzF247h/vqHe3/tt6fgtXeG9wdjjoetdI/vA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-9.1.1.tgz",
+      "integrity": "sha512-iJrnjgR4FWQIXZkUF48oNgoRI9BpyMhaEmihonHeCnZ6F50ZHAS4YGfGBT/ZVNsPmd+hzkIPGzjKdY08+/yAXw==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/colorette": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "dev": true
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
     "node_modules/pkg-conf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
@@ -6089,6 +6442,11 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.1.0.tgz",
+      "integrity": "sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg=="
+    },
     "node_modules/prompt": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
@@ -6124,19 +6482,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "node_modules/pumpify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
-      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
-      "dependencies": {
-        "duplexify": "^4.1.1",
-        "inherits": "^2.0.3",
-        "pump": "^3.0.0"
       }
     },
     "node_modules/punycode": {
@@ -6181,6 +6530,11 @@
         }
       ]
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -6221,16 +6575,25 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
@@ -6501,9 +6864,23 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -6513,10 +6890,24 @@
         "ret": "~0.1.10"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.6.0.tgz",
+      "integrity": "sha512-B9osKohb6L+EZ6Kve3wHKfsAClzOC/iISA2vSuCe5Jx5NAKiwitfxx8ZKYapHXr0sYRj7UZInT7pLb3rp2Yx6A==",
+      "dev": true
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",
@@ -6831,6 +7222,14 @@
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.1.tgz",
+      "integrity": "sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -7159,37 +7558,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -7322,6 +7698,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.2.0.tgz",
+      "integrity": "sha512-rUkv4/fnb4rqy/gGy7VuqK6wE1+1DOCOWy4RMeaV69ZHMP11tQKZvZSip1yTgrKCMZzEMcCL/bKfHvSfDHx+iQ==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/tildify": {
       "version": "2.0.0",
@@ -7689,7 +8073,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/util/node_modules/inherits": {
       "version": "2.0.3",
@@ -7875,7 +8260,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
@@ -8575,17 +8961,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
       "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
-    "@hapi/good": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/good/-/good-9.0.1.tgz",
-      "integrity": "sha512-zHSjw+LieqDgu5pXLUHqUJTMSgBKIdKHwxmXNoh9qVz+kSPQH463ol6OEBSTVdy0yQawKVI4eAyeqown++TpbA==",
-      "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/oppsy": "3.x.x",
-        "@hapi/validate": "1.x.x",
-        "pumpify": "2.x.x"
-      }
-    },
     "@hapi/hapi": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.1.0.tgz",
@@ -8761,14 +9136,6 @@
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
           "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
         }
-      }
-    },
-    "@hapi/oppsy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/oppsy/-/oppsy-3.0.0.tgz",
-      "integrity": "sha512-0kfUEAqIi21GzFVK2snMO07znMEBiXb+/pOx1dmgOO9TuvFstcfmHU5i56aDfiFP2DM5WzQCU2UWc2gK1lMDhQ==",
-      "requires": {
-        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/pez": {
@@ -9147,11 +9514,128 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
+    "@types/hapi__catbox": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
+      "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg=="
+    },
+    "@types/hapi__hapi": {
+      "version": "20.0.13",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.13.tgz",
+      "integrity": "sha512-LP4IPfhIO5ZPVOrJo7H8c8Slc0WYTFAUNQX1U0LBPKyXioXhH5H2TawIgxKujIyOhbwoBbpvOsBf6o5+ToJIrQ==",
+      "requires": {
+        "@hapi/boom": "^9.0.0",
+        "@hapi/iron": "^6.0.0",
+        "@hapi/podium": "^4.1.3",
+        "@types/hapi__catbox": "*",
+        "@types/hapi__mimos": "*",
+        "@types/hapi__shot": "*",
+        "@types/node": "*",
+        "joi": "^17.3.0"
+      },
+      "dependencies": {
+        "@hapi/b64": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+          "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/boom": {
+          "version": "9.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+          "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/bourne": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+          "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+        },
+        "@hapi/cryptiles": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+          "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+          "requires": {
+            "@hapi/boom": "9.x.x"
+          }
+        },
+        "@hapi/iron": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+          "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+          "requires": {
+            "@hapi/b64": "5.x.x",
+            "@hapi/boom": "9.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/cryptiles": "5.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/podium": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+          "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+          "requires": {
+            "@hapi/hoek": "9.x.x",
+            "@hapi/teamwork": "5.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/teamwork": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+          "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg=="
+        }
+      }
+    },
+    "@types/hapi__mimos": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
+      "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
+      "requires": {
+        "@types/mime-db": "*"
+      }
+    },
+    "@types/hapi__shot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
+      "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/mime-db": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
+      "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ=="
+    },
+    "@types/node": {
+      "version": "18.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.12.tgz",
+      "integrity": "sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg=="
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "acorn": {
       "version": "8.8.1",
@@ -9303,6 +9787,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -9341,6 +9830,11 @@
           }
         }
       }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -9454,6 +9948,15 @@
         "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.9"
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-equal-constant-time": {
@@ -9784,6 +10287,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true
+    },
     "db-migrate": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/db-migrate/-/db-migrate-0.11.13.tgz",
@@ -9949,17 +10458,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
-    "duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "requires": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "easy-table": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
@@ -10001,6 +10499,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -10647,6 +11146,16 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -10833,6 +11342,12 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ=="
     },
+    "fast-copy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
+      "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10860,6 +11375,17 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "fastq": {
@@ -11262,16 +11788,6 @@
         }
       }
     },
-    "good-winston": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/good-winston/-/good-winston-4.0.0.tgz",
-      "integrity": "sha512-ensNvhqlXsm0D1xY4o+TwBSJL/AZGHH7dlxLFMIeicJ7a6B80Ld15XEkFFXNoRHjAgkXm2d7otjgzExiwAASCw==",
-      "requires": {
-        "hoek": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "moment": "^2.18.1"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -11322,6 +11838,25 @@
           "requires": {
             "@hapi/hoek": "9.x.x"
           }
+        }
+      }
+    },
+    "hapi-pino": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-11.0.1.tgz",
+      "integrity": "sha512-H09Cwh9pjpGJOBopswqszX5K5pygOke+5Wo25TCjG1MqTqDy7zzwFKkVHrY8IhsTdy99lewxBrOWsCMrcN8zPg==",
+      "requires": {
+        "@hapi/hoek": "^10.0.0",
+        "@types/hapi__hapi": "^20.0.10",
+        "abstract-logging": "^2.0.1",
+        "get-caller-file": "^2.0.5",
+        "pino": "^8.5.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-10.0.1.tgz",
+          "integrity": "sha512-CvlW7jmOhWzuqOqiJQ3rQVLMcREh0eel4IBnxDx2FAcK8g7qoJRQK4L1CPBASoCY6y8e6zuCy3f2g+HWdkzcMw=="
         }
       }
     },
@@ -11428,10 +11963,59 @@
         }
       }
     },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    "help-me": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.1.0.tgz",
+      "integrity": "sha512-5HMrkOks2j8Fpu2j5nTLhrBhT7VwHwELpqnSnx802ckofys5MO2SkLpgSz3dgNFHV7IYFX2igm5CM75SmuYidw==",
+      "dev": true,
+      "requires": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+          "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -11450,6 +12034,11 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "immutability-helper": {
       "version": "3.1.1",
@@ -11490,7 +12079,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -11766,6 +12356,12 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true
     },
     "js-sdsl": {
       "version": "4.1.4",
@@ -12447,10 +13043,16 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -12688,6 +13290,68 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
+    "pino": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.7.0.tgz",
+      "integrity": "sha512-l9sA5uPxmZzwydhMWUcm1gI0YxNnYl8MfSr2h8cwLvOAzQLBLewzF247h/vqHe3/tt6fgtXeG9wdjjoetdI/vA==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "requires": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "pino-pretty": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-9.1.1.tgz",
+      "integrity": "sha512-iJrnjgR4FWQIXZkUF48oNgoRI9BpyMhaEmihonHeCnZ6F50ZHAS4YGfGBT/ZVNsPmd+hzkIPGzjKdY08+/yAXw==",
+      "dev": true,
+      "requires": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "2.0.19",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+          "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+          "dev": true
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
     "pkg-conf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
@@ -12751,6 +13415,11 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
+    "process-warning": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.1.0.tgz",
+      "integrity": "sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg=="
+    },
     "prompt": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
@@ -12783,19 +13452,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "pumpify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
-      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
-      "requires": {
-        "duplexify": "^4.1.1",
-        "inherits": "^2.0.3",
-        "pump": "^3.0.0"
       }
     },
     "punycode": {
@@ -12816,6 +13476,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "rc": {
       "version": "1.2.8",
@@ -12850,14 +13515,20 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
       }
+    },
+    "real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
     },
     "rechoir": {
       "version": "0.6.2",
@@ -13035,9 +13706,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -13047,10 +13718,21 @@
         "ret": "~0.1.10"
       }
     },
+    "safe-stable-stringify": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "secure-json-parse": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.6.0.tgz",
+      "integrity": "sha512-B9osKohb6L+EZ6Kve3wHKfsAClzOC/iISA2vSuCe5Jx5NAKiwitfxx8ZKYapHXr0sYRj7UZInT7pLb3rp2Yx6A==",
+      "dev": true
     },
     "seedrandom": {
       "version": "3.0.5",
@@ -13302,6 +13984,14 @@
         }
       }
     },
+    "sonic-boom": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.1.tgz",
+      "integrity": "sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -13507,24 +14197,13 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
     },
-    "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
       }
     },
     "string-width": {
@@ -13619,6 +14298,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "thread-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.2.0.tgz",
+      "integrity": "sha512-rUkv4/fnb4rqy/gGy7VuqK6wE1+1DOCOWy4RMeaV69ZHMP11tQKZvZSip1yTgrKCMZzEMcCL/bKfHvSfDHx+iQ==",
+      "requires": {
+        "real-require": "^0.2.0"
+      }
     },
     "tildify": {
       "version": "2.0.0",
@@ -13912,7 +14599,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "uuid": {
       "version": "9.0.0",
@@ -14059,7 +14747,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@envage/hapi-pg-rest-api": "^7.0.0",
     "@envage/water-abstraction-helpers": "4.8.3",
     "@hapi/boom": "^10.0.0",
-    "@hapi/good": "^9.0.1",
     "@hapi/hapi": "^21.0.0",
     "@joi/date": "^2.1.0",
     "blipp": "^4.0.2",
@@ -33,8 +32,8 @@
     "db-migrate-pg": "^1.2.2",
     "deep-map-keys": "^2.0.1",
     "dotenv": "^16.0.3",
-    "good-winston": "^4.0.0",
     "hapi-auth-jwt2": "^10.2.0",
+    "hapi-pino": "^11.0.1",
     "joi": "^17.7.0",
     "knex": "^0.21.21",
     "moment": "^2.29.4",
@@ -50,6 +49,7 @@
   "devDependencies": {
     "@hapi/code": "^9.0.1",
     "@hapi/lab": "^25.0.1",
+    "pino-pretty": "^9.1.1",
     "sinon": "^14.0.2",
     "standard": "^17.0.0"
   }

--- a/src/lib/services/hapi-pino-ignore-request.service.js
+++ b/src/lib/services/hapi-pino-ignore-request.service.js
@@ -5,30 +5,30 @@
  * @module HapiPinoIgnoreRequestService
  */
 
-class HapiPinoIgnoreRequestService {
-  /**
-   * Returns true or false whether a request should be loged
-   *
-   * Used by `src/plugins/hapi_pino.plugin.js` to control what does and doesn't get added to our log output. `/status`
-   * is to support the AWS load balancer health checks which fire approximately every 500ms. If we logged these
-   * requests our log would be too noisy to prove useful.
-   *
-   * @param {Object} _options The options passed to the HapiPino plugin
-   * @param {request} request Hapi request object created internally for each incoming request
-   *
-   * @returns {boolean} true if the request should be ignored, else false
-   */
-  static go (_options, request) {
-    const staticPaths = ['/status', '/favicon.ico']
+/**
+ * Returns true or false whether a request should be loged
+ *
+ * Used by `src/plugins/hapi_pino.plugin.js` to control what does and doesn't get added to our log output. `/status`
+ * is to support the AWS load balancer health checks which fire approximately every 500ms. If we logged these
+ * requests our log would be too noisy to prove useful.
+ *
+ * @param {Object} _options The options passed to the HapiPino plugin
+ * @param {request} request Hapi request object created internally for each incoming request
+ *
+ * @returns {boolean} true if the request should be ignored, else false
+ */
+function go (_options, request) {
+  const staticPaths = ['/status', '/favicon.ico']
 
-    // If request is a known path ignore it
-    if (staticPaths.includes(request.path)) {
-      return true
-    }
-
-    // Do not ignore all other requests
-    return false
+  // If request is a known path ignore it
+  if (staticPaths.includes(request.path)) {
+    return true
   }
+
+  // Do not ignore all other requests
+  return false
 }
 
-module.exports = HapiPinoIgnoreRequestService
+module.exports = {
+  go
+}

--- a/src/lib/services/hapi-pino-ignore-request.service.js
+++ b/src/lib/services/hapi-pino-ignore-request.service.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * Used by HapiPinoPlugin to determine which requests to log
+ * @module HapiPinoIgnoreRequestService
+ */
+
+class HapiPinoIgnoreRequestService {
+  /**
+   * Returns true or false whether a request should be loged
+   *
+   * Used by `src/plugins/hapi_pino.plugin.js` to control what does and doesn't get added to our log output. `/status`
+   * is to support the AWS load balancer health checks which fire approximately every 500ms. If we logged these
+   * requests our log would be too noisy to prove useful.
+   *
+   * @param {Object} _options The options passed to the HapiPino plugin
+   * @param {request} request Hapi request object created internally for each incoming request
+   *
+   * @returns {boolean} true if the request should be ignored, else false
+   */
+  static go (_options, request) {
+    const staticPaths = ['/status', '/favicon.ico']
+
+    // If request is a known path ignore it
+    if (staticPaths.includes(request.path)) {
+      return true
+    }
+
+    // Do not ignore all other requests
+    return false
+  }
+}
+
+module.exports = HapiPinoIgnoreRequestService

--- a/src/plugins/hapi-pino.plugin.js
+++ b/src/plugins/hapi-pino.plugin.js
@@ -1,0 +1,64 @@
+'use strict'
+
+/**
+ * Plugin that handles logging for the application
+ *
+ * {@link https://github.com/pinojs/hapi-pino|hapi-pino} wraps the
+ * {@link https://github.com/pinojs/pino#low-overhead|pino} Node JSON logger as a logger for Hapi. We pretty much use it
+ * as provided with its defaults.
+ *
+ * @module HapiPinoPlugin
+ */
+
+const HapiPino = require('hapi-pino')
+
+const HapiPinoIgnoreRequestService = require('../lib/services/hapi-pino-ignore-request.service.js')
+
+const config = require('../../config.js')
+
+/**
+ * Return test configuration options for the logger
+ *
+ * When we run our unit tests we don't want the output polluted by noise from the logger. So as a default we set the
+ * configuration to tell hapi-pino to ignore all events.
+ *
+ * But there will be times when trying to diagnose an issue that we will want log output. So using an env var we can
+ * override the default and tell hapi-pino to log everything as normal.
+ *
+ * In both cases using the
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax|spread operator} on
+ * the returned value will allow it to be incorporated with our default hapi-pino options.
+ */
+const testOptions = () => {
+  if (process.env.NODE_ENV !== 'test' || config.log.logInTest) {
+    return {}
+  }
+
+  return {
+    // Don't log requests etc
+    logEvents: false,
+    // Don't log anything tagged with DEBUG or info, for example, req.log(['INFO'], 'User is an admin')
+    ignoredEventTags: { log: ['DEBUG', 'INFO'], request: ['DEBUG', 'INFO'] }
+  }
+}
+
+const HapiPinoPlugin = () => {
+  return {
+    plugin: HapiPino,
+    options: {
+      // Include our test configuration
+      ...testOptions(),
+      // When not in the production environment we want a 'pretty' version of the JSON to make it easier to grok what has
+      // happened
+      transport: process.env.NODE_ENV !== 'production' ? { target: 'pino-pretty', options: { colorize: true } } : undefined,
+      // Redact Authorization headers, see https://getpino.io/#/docs/redaction
+      redact: ['req.headers.authorization'],
+      // We want our logs to focus on the main requests and not become full of 'noise' from requests for /assets or
+      // pings from the AWS load balancer to /status. We pass this function to hapi-pino to control what gets filtered
+      // https://github.com/pinojs/hapi-pino#optionsignorefunc-options-request--boolean
+      ignoreFunc: HapiPinoIgnoreRequestService.go
+    }
+  }
+}
+
+module.exports = HapiPinoPlugin

--- a/test/lib/services/hapi-pino-ignore-request.service.test.js
+++ b/test/lib/services/hapi-pino-ignore-request.service.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Thing under test
+const HapiPinoIgnoreRequestService = require('../../../src/lib/services/hapi-pino-ignore-request.service.js')
+
+describe('Hapi Pino Ignore Request service', () => {
+  const _options = {}
+
+  describe("when the request is for '/status'", () => {
+    it('returns true', () => {
+      const result = HapiPinoIgnoreRequestService.go(_options, { path: '/status' })
+
+      expect(result).to.be.true()
+    })
+  })
+
+  describe("when the request is for '/favicon.ico'", () => {
+    it('returns true', () => {
+      const result = HapiPinoIgnoreRequestService.go(_options, { path: '/favicon.ico' })
+
+      expect(result).to.be.true()
+    })
+  })
+
+  describe("when the request is not for '/status'", () => {
+    it('returns false', () => {
+      const result = HapiPinoIgnoreRequestService.go(_options, { path: '/bill-run/stuff' })
+
+      expect(result).to.be.false()
+    })
+  })
+})


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/66

[@hapi/good](https://www.npmjs.com/package/@hapi/good) is in all our app repos and is used to report stats on the running apps. The problem is it generates a horrendous amount of noise in our logs, and as of Dec 31 2020 was deprecated 😩 .

For those perfectly 'good' reasons, we need to strip it out of all repos where it is used.

The problem is it is also responsible for logging all requests and responses. Our preferred logger for this is [hapi-pino](https://github.com/pinojs/hapi-pino). It's still supported, fast, and outputs in JSON format. It also allows us to control what exactly gets logged, for example, we can suppress logging calls to `/status` which pollutes our logs in **production**.

So, this change replaces **hapi/good** with **hapi-pino**.