### PR TITLE
Add defaults to unused columns in crm_v2.documents

### DIFF
--- a/migrations/20231221153217-alter-crm-v2-documents.js
+++ b/migrations/20231221153217-alter-crm-v2-documents.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20231221153217-alter-crm-v2-documents-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20231221153217-alter-crm-v2-documents-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20231221153217-alter-crm-v2-documents-down.sql
+++ b/migrations/sqls/20231221153217-alter-crm-v2-documents-down.sql
@@ -1,0 +1,5 @@
+/* See https://eaflood.atlassian.net/browse/WATER-4292 */
+
+ALTER TABLE crm_v2.documents ALTER COLUMN regime DROP DEFAULT;
+
+ALTER TABLE crm_v2.documents ALTER COLUMN document_type DROP DEFAULT;

--- a/migrations/sqls/20231221153217-alter-crm-v2-documents-up.sql
+++ b/migrations/sqls/20231221153217-alter-crm-v2-documents-up.sql
@@ -1,0 +1,5 @@
+/* See https://eaflood.atlassian.net/browse/WATER-4292 */
+
+ALTER TABLE crm_v2.documents ALTER COLUMN regime SET DEFAULT 'water';
+
+ALTER TABLE crm_v2.documents ALTER COLUMN document_type SET DEFAULT 'abstraction_licence';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4292

As part of making the migrations work in `water-abstraction-system` we have been creating DB Views of the legacy crm data that better represent the data as we use it in our new service. Part of this exercise is pruning out the unused columns that exist in the legacy tables that are not utilised.

However, we have found that for some of the columns in the legacy data, whilst pointless, still need to be populated as they are set to `Not Nullable` in the legacy database tables. Therefore, we will set a default value for these columns in the legacy DB so that they are always populated even when they do not exist in our new Views.

The table columns that will be affected by this PR are:

- `crm_v2.documents.regime` - this is always "water" so it will default to "water"
- `crm_v2.documents.document_type` - this is always "abstraction_licence" so it will default to "abstraction_licence"