### PR TITLE
Add defaults to unused column crm.document_header

### DIFF
--- a/migrations/20240107235932-alter-crm-document-header.js
+++ b/migrations/20240107235932-alter-crm-document-header.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240107235932-alter-crm-document-header-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240107235932-alter-crm-document-header-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240107235932-alter-crm-document-header-down.sql
+++ b/migrations/sqls/20240107235932-alter-crm-document-header-down.sql
@@ -1,0 +1,3 @@
+/* Replace with your SQL commands *//* See https://eaflood.atlassian.net/browse/WATER-4292 */
+
+ALTER TABLE crm.document_header ALTER COLUMN system_id DROP DEFAULT;

--- a/migrations/sqls/20240107235932-alter-crm-document-header-up.sql
+++ b/migrations/sqls/20240107235932-alter-crm-document-header-up.sql
@@ -1,0 +1,3 @@
+/* See https://eaflood.atlassian.net/browse/WATER-4292 */
+
+ALTER TABLE crm.document_header ALTER COLUMN system_id SET DEFAULT 'permit-repo';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4292

As part of making the migrations work in `water-abstraction-system` we have been creating DB Views of the legacy crm data that better represent the data as we use it in our new service. Part of this exercise is pruning out the unused columns that exist in the legacy tables that are not utilised.

However, we have found that some of the columns in the legacy data, whilst pointless, still need to be populated as they are set to `Not Nullable` in the legacy database tables. Therefore, we will set a default value for these columns in the legacy DB so that they are always populated even when they do not exist in our new Views.

The table columns that will be affected by this PR are:

- `crm.document_header.system_id` - this is always "permit-repo" so it will default to "permit-repo"