### PR TITLE
Removing console.log() from legacy migrations

### DIFF
--- a/migrations/20171201091402-crm.js
+++ b/migrations/20171201091402-crm.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171204113320-add-role-documentview.js
+++ b/migrations/20171204113320-add-role-documentview.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171204114142-modify-role-documentview.js
+++ b/migrations/20171204114142-modify-role-documentview.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171204151443-add-colleague.js
+++ b/migrations/20171204151443-add-colleague.js
@@ -5,7 +5,6 @@ exports.up = function (db, callback) {
   const filePath = path.join(__dirname, '/sqls/20171204151443-add-colleague-up.sql')
   fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
     if (err) return callback(err)
-    console.log('received data: ' + data)
 
     db.runSql(data, function (err) {
       if (err) return callback(err)
@@ -18,7 +17,6 @@ exports.down = function (db, callback) {
   const filePath = path.join(__dirname, '/sqls/20171204151443-add-colleague-down.sql')
   fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
     if (err) return callback(err)
-    console.log('received data: ' + data)
 
     db.runSql(data, function (err) {
       if (err) return callback(err)

--- a/migrations/20171207153055-add-verification.js
+++ b/migrations/20171207153055-add-verification.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171207160615-add-verification-documents.js
+++ b/migrations/20171207160615-add-verification-documents.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171212152141-document-header-upsert.js
+++ b/migrations/20171212152141-document-header-upsert.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171214102132-modify-role-documentview.js
+++ b/migrations/20171214102132-modify-role-documentview.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171218085641-setup-beta-private-companies.js
+++ b/migrations/20171218085641-setup-beta-private-companies.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180119134127-remove-unique-nm-type-constraint.js
+++ b/migrations/20180119134127-remove-unique-nm-type-constraint.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180202150305-optimise-query.js
+++ b/migrations/20180202150305-optimise-query.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180212081214-jsonb.js
+++ b/migrations/20180212081214-jsonb.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180323143100-add-verification-documents-table.js
+++ b/migrations/20180323143100-add-verification-documents-table.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180410075756-roles-in-db.js
+++ b/migrations/20180410075756-roles-in-db.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180410092553-roles-detailed-view.js
+++ b/migrations/20180410092553-roles-detailed-view.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180411115741-licence-name-in-documents-table.js
+++ b/migrations/20180411115741-licence-name-in-documents-table.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180420074342-add-document-contacts.js
+++ b/migrations/20180420074342-add-document-contacts.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180430142808-add-kpi-reports.js
+++ b/migrations/20180430142808-add-kpi-reports.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180501081416-more-queries.js
+++ b/migrations/20180501081416-more-queries.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180719050252-entity-roles-remove-is-primary.js
+++ b/migrations/20180719050252-entity-roles-remove-is-primary.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180719084321-entity-roles-add-permissions.js
+++ b/migrations/20180719084321-entity-roles-add-permissions.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180723144638-remove-document-association.js
+++ b/migrations/20180723144638-remove-document-association.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180723145145-remove-entity-association.js
+++ b/migrations/20180723145145-remove-entity-association.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180723145213-remove-entity-document-metadata.js
+++ b/migrations/20180723145213-remove-entity-document-metadata.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180730151149-entity-roles-remove-permissions-field.js
+++ b/migrations/20180730151149-entity-roles-remove-permissions-field.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180809163444-lowercase-individuals-emails.js
+++ b/migrations/20180809163444-lowercase-individuals-emails.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180828134701-update-entity-roles-unique-constraint.js
+++ b/migrations/20180828134701-update-entity-roles-unique-constraint.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180830125930-update-entity-roles-unique-constraint.js
+++ b/migrations/20180830125930-update-entity-roles-unique-constraint.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20181123165313-remove-erroneous-verification-id.js
+++ b/migrations/20181123165313-remove-erroneous-verification-id.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20181207111755-entity-add-date-created.js
+++ b/migrations/20181207111755-entity-add-date-created.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20181207115121-document-header-drop-verified.js
+++ b/migrations/20181207115121-document-header-drop-verified.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190905133546-crm-v2-structure.js
+++ b/migrations/20190905133546-crm-v2-structure.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190924150207-add-invoice-accounts-table.js
+++ b/migrations/20190924150207-add-invoice-accounts-table.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190925111236-unique-external-id.js
+++ b/migrations/20190925111236-unique-external-id.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20191010103013-licence-holder-role.js
+++ b/migrations/20191010103013-licence-holder-role.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20191021152244-rename-ias-account-number.js
+++ b/migrations/20191021152244-rename-ias-account-number.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20191101151039-varchar-to-uuid.js
+++ b/migrations/20191101151039-varchar-to-uuid.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20191115164516-crm-v2-company-constraint.js
+++ b/migrations/20191115164516-crm-v2-company-constraint.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20191126172844-change-document-external-id.js
+++ b/migrations/20191126172844-change-document-external-id.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20191203111359-document-header-index.js
+++ b/migrations/20191203111359-document-header-index.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20200411131657-add-is-test-column.js
+++ b/migrations/20200411131657-add-is-test-column.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20200610085712-invoice-account-roles.js
+++ b/migrations/20200610085712-invoice-account-roles.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20200629141555-contact-address-additional-fields.js
+++ b/migrations/20200629141555-contact-address-additional-fields.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20200630152652-remove-address-1-not-null.js
+++ b/migrations/20200630152652-remove-address-1-not-null.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20200707095638-add-organisation-type-to-companies-table.js
+++ b/migrations/20200707095638-add-organisation-type-to-companies-table.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20201001074246-add-returns-to-role.js
+++ b/migrations/20201001074246-add-returns-to-role.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20201020083236-document-date-deleted.js
+++ b/migrations/20201020083236-document-date-deleted.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20201202105741-address-uprn-unique.js
+++ b/migrations/20201202105741-address-uprn-unique.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20210323171609-remove-document-billing-roles.js
+++ b/migrations/20210323171609-remove-document-billing-roles.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20210429104232-entity-hash-columns.js
+++ b/migrations/20210429104232-entity-hash-columns.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20210611083955-remove-document-versions.js
+++ b/migrations/20210611083955-remove-document-versions.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20211011171839-role-labels.js
+++ b/migrations/20211011171839-role-labels.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20211018084228-invoice-account-sop-metadata-cols.js
+++ b/migrations/20211018084228-invoice-account-sop-metadata-cols.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20211021114806-waa-contact-preferences-cols.js
+++ b/migrations/20211021114806-waa-contact-preferences-cols.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20211021195009-new-licence-role.js
+++ b/migrations/20211021195009-new-licence-role.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20211116131609-fix-contacts.js
+++ b/migrations/20211116131609-fix-contacts.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20221018092848-remove-problem-licences.js
+++ b/migrations/20221018092848-remove-problem-licences.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/91

This PR is focusing on removing console.log() from legacy migrations as per Teams issue. When working on https://github.com/DEFRA/water-abstraction-service/pull/2227 we again broke GitHub CI because of the volume of output from our migrations.

In https://github.com/DEFRA/water-abstraction-team/issues/65 we thought we'd dealt with the issue believing that [db-mgrate's verbose()](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/installation/#basic-usage) argument was to blame.

Looking into the issue in the stuck bill run we came across a https://github.com/db-migrate/node-db-migrate/issues/453#issuecomment-278471581 that gave us a 🤦 !

The db-migrate template used when generating migrations includes a console.log() that outputs the migration file read in. So, though we might not be outputting all the SQL being fired, we are still outputting the contents of every single migration file!

We definitely don't need to see this and it should remove the chance of us breaking the build in this way once and for all. 

So, this issue is about going into the existing migrations and removing the 2 console.log('received data: ' + data) lines in each across all repos.