### PR TITLE
Remove /invoice-accounts/recently-updated endpoint

### DIFF
--- a/src/v2/connectors/repository/invoice-accounts.js
+++ b/src/v2/connectors/repository/invoice-accounts.js
@@ -106,8 +106,6 @@ const deleteTestData = async () => {
   await helpers.deleteTestData(InvoiceAccount)
 }
 
-const findAllWhereEntitiesHaveUnmatchingHashes = () => raw.multiRow(queries.findAllWhereEntitiesHaveUnmatchingHashes)
-
 const updateInvoiceAccountsWithCustomerFileReference = (fileReference, exportedAt, exportedCustomers) =>
   raw.multiRow(queries.updateInvoiceAccountsWithCustomerFileReference, {
     fileReference, exportedAt, exportedCustomers
@@ -120,5 +118,4 @@ exports.findOne = findOne
 exports.findOneByAccountNumber = findOneByAccountNumber
 exports.findWithCurrentAddress = findWithCurrentAddress
 exports.findAllByCompanyId = findAllByCompanyId
-exports.findAllWhereEntitiesHaveUnmatchingHashes = findAllWhereEntitiesHaveUnmatchingHashes
 exports.updateInvoiceAccountsWithCustomerFileReference = updateInvoiceAccountsWithCustomerFileReference

--- a/src/v2/connectors/repository/queries/invoice-accounts.js
+++ b/src/v2/connectors/repository/queries/invoice-accounts.js
@@ -1,19 +1,5 @@
 'use strict'
 
-exports.findAllWhereEntitiesHaveUnmatchingHashes = `
-select distinct ia.invoice_account_id, ia.invoice_account_number, com.external_id as company_legacy_id
-from crm_v2.invoice_accounts ia
-left join crm_v2.invoice_account_addresses iaa on iaa.invoice_account_id = ia.invoice_account_id
-left join crm_v2.companies com on ia.company_id = com.company_id or iaa.agent_company_id = com.company_id
-left join crm_v2.company_contacts comcon on comcon.company_id = com.company_id
-left join crm_v2.company_addresses comadd on comadd.company_id = com.company_id
-left join crm_v2.contacts con on con.contact_id = comcon.contact_id or con.contact_id = iaa.contact_id
-left join crm_v2.addresses add on add.address_id = iaa.address_id or comadd.address_id = add.address_id
-where com.last_hash <> com.current_hash
-or con.last_hash <> con.current_hash
-or add.last_hash <> add.current_hash
-`
-
 exports.deleteTestInvoiceAccounts = `
 DELETE from crm_v2.invoice_accounts where company_id IN (SELECT company_id from crm_v2.companies where is_test = true);`
 

--- a/src/v2/modules/invoice-accounts/controller.js
+++ b/src/v2/modules/invoice-accounts/controller.js
@@ -14,15 +14,6 @@ const getInvoiceAccounts = async request => {
   }
 }
 
-const getInvoiceAccountsWithRecentlyUpdatedEntities = async () => {
-  try {
-    return invoiceAccountService.getInvoiceAccountsWithRecentlyUpdatedEntities()
-  } catch (err) {
-    logger.error('Could not get recently updated invoice accounts', err.stack)
-    return Boom.boomify(err)
-  }
-}
-
 const getInvoiceAccountByRef = async request => {
   try {
     const { ref } = request.query
@@ -48,6 +39,5 @@ const updateInvoiceAccountsWithCustomerFileReference = async (request, h) => {
 }
 
 exports.getInvoiceAccounts = getInvoiceAccounts
-exports.getInvoiceAccountsWithRecentlyUpdatedEntities = getInvoiceAccountsWithRecentlyUpdatedEntities
 exports.getInvoiceAccountByRef = getInvoiceAccountByRef
 exports.updateInvoiceAccountsWithCustomerFileReference = updateInvoiceAccountsWithCustomerFileReference

--- a/src/v2/modules/invoice-accounts/routes.js
+++ b/src/v2/modules/invoice-accounts/routes.js
@@ -78,15 +78,6 @@ exports.deleteInvoiceAccount = {
   }
 }
 
-exports.getInvoiceAccountsWithRecentlyUpdatedEntities = {
-  method: 'GET',
-  path: '/crm/2.0/invoice-accounts/recently-updated',
-  handler: controller.getInvoiceAccountsWithRecentlyUpdatedEntities,
-  options: {
-    description: 'Get all invoice accounts whose underlying entities have unmatching current_hash vs last_hash'
-  }
-}
-
 exports.updateInvoiceAccountsWithCustomerFileReference = {
   method: 'POST',
   path: '/crm/2.0/invoice-accounts/customer-file-references',

--- a/src/v2/services/invoice-accounts.js
+++ b/src/v2/services/invoice-accounts.js
@@ -58,12 +58,9 @@ const getInvoiceAccountsByIds = async ids => {
   return results.map(mappers.invoiceAccount.mostRecentAddressOnly)
 }
 
-const getInvoiceAccountsWithRecentlyUpdatedEntities = () => invoiceAccountsRepo.findAllWhereEntitiesHaveUnmatchingHashes()
-
 exports.createInvoiceAccount = createInvoiceAccount
 exports.getInvoiceAccountByRef = getInvoiceAccountByRef
 exports.deleteInvoiceAccount = deleteInvoiceAccount
 exports.getInvoiceAccount = getInvoiceAccount
 exports.getInvoiceAccountsByIds = getInvoiceAccountsByIds
-exports.getInvoiceAccountsWithRecentlyUpdatedEntities = getInvoiceAccountsWithRecentlyUpdatedEntities
 exports.updateInvoiceAccountsWithCustomerFileReference = invoiceAccountsRepo.updateInvoiceAccountsWithCustomerFileReference

--- a/test/v2/connectors/repository/invoice-accounts.test.js
+++ b/test/v2/connectors/repository/invoice-accounts.test.js
@@ -215,17 +215,6 @@ experiment('v2/connectors/repository/invoice-account', () => {
     })
   })
 
-  experiment('.findAllWhereEntitiesHaveUnmatchingHashes', () => {
-    beforeEach(async () => {
-      await invoiceAccounts.findAllWhereEntitiesHaveUnmatchingHashes()
-    })
-
-    test('calls raw.multiRow with the correct query and params', async () => {
-      const [query] = raw.multiRow.lastCall.args
-      expect(query).to.equal(queries.findAllWhereEntitiesHaveUnmatchingHashes)
-    })
-  })
-
   experiment('.updateInvoiceAccountsWithCustomerFileReference', () => {
     beforeEach(async () => {
       await invoiceAccounts.updateInvoiceAccountsWithCustomerFileReference()

--- a/test/v2/modules/invoice-accounts/controller.test.js
+++ b/test/v2/modules/invoice-accounts/controller.test.js
@@ -16,7 +16,6 @@ const request = {
 experiment('v2/modules/invoice-accounts/controller', () => {
   beforeEach(async () => {
     sandbox.stub(invoiceAccountsService, 'getInvoiceAccountsByIds').resolves([])
-    sandbox.stub(invoiceAccountsService, 'getInvoiceAccountsWithRecentlyUpdatedEntities').resolves([])
     sandbox.stub(invoiceAccountsService, 'updateInvoiceAccountsWithCustomerFileReference').resolves()
     sandbox.stub(invoiceAccountsService, 'getInvoiceAccountByRef').resolves()
   })
@@ -67,12 +66,6 @@ experiment('v2/modules/invoice-accounts/controller', () => {
 
         expect(response).to.equal(invoiceAccounts)
       })
-    })
-  })
-  experiment('.getInvoiceAccountsWithRecentlyUpdatedEntities', () => {
-    test('calls the invoiceAccountsService', async () => {
-      await controller.getInvoiceAccountsWithRecentlyUpdatedEntities()
-      expect(invoiceAccountsService.getInvoiceAccountsWithRecentlyUpdatedEntities.called).to.be.true()
     })
   })
   experiment('.getInvoiceAccountByRef', () => {

--- a/test/v2/services/invoice-accounts.test.js
+++ b/test/v2/services/invoice-accounts.test.js
@@ -288,11 +288,4 @@ experiment('v2/services/invoice-accounts', () => {
       expect(invoiceAccountsRepo.deleteOne.calledWith('test-invoice-account-id')).to.be.true()
     })
   })
-
-  experiment('.getInvoiceAccountsWithRecentlyUpdatedEntities', () => {
-    test('calls the findAllWhereEntitiesHaveUnmatchingHashes repo method', async () => {
-      await invoiceAccountsService.getInvoiceAccountsWithRecentlyUpdatedEntities()
-      expect(invoiceAccountsRepo.findAllWhereEntitiesHaveUnmatchingHashes.called).to.be.true()
-    })
-  })
 })

--- a/test/v2/services/invoice-accounts.test.js
+++ b/test/v2/services/invoice-accounts.test.js
@@ -64,7 +64,6 @@ experiment('v2/services/invoice-accounts', () => {
     sandbox.stub(invoiceAccountsRepo, 'findOneByAccountNumber')
     sandbox.stub(invoiceAccountsRepo, 'findWithCurrentAddress')
     sandbox.stub(invoiceAccountsRepo, 'deleteOne')
-    sandbox.stub(invoiceAccountsRepo, 'findAllWhereEntitiesHaveUnmatchingHashes').resolves([])
     sandbox.stub(invoiceAccountAddressesRepo, 'findAll').resolves([{ startDate: '2018-05-03', endDate: '2020-03-31' }])
     sandbox.stub(invoiceAccountAddressesRepo, 'create')
     sandbox.stub(invoiceAccountAddressesRepo, 'deleteOne')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4437

The [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) had a scheduled job [Licence not in charge version workflow](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/service.md#licence-not-in-charge-version-workflow). It's intent was to add a `water.charge_version_workflow` record any time it saw a new or updated licence.

Our understanding is this was intended to keep the licence from being included in a bill run until Billing & Data has had a chance to review its charge versions.

However, it appeared to have stopped working. When we dug in we realised it seemed BullMQ jobs that were scheduled using cron syntax were not always getting their repeated jobs repeated! That was resolved with [New job to add new & updated licences to workflow](https://github.com/DEFRA/water-abstraction-system/pull/903). But it caused us to check the other jobs scheduled in this way.

[Digitise To Licence Gauging Stations](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/service.md#digitise-to-licence-gauging-stations) and [Digitise to Licence Version Purpose (LVP) Sync](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/service.md#digitise-to-licence-version-purpose-lvp-sync) displayed the same sporadic behaviour when we checked the logs.

[Check for updated invoice accounts](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/service.md#check-for-updated-invoice-accounts) (otherwise known as `billing.find-update-invoice-accounts`) was never being run at all! 😱

Because it was not assigned a BullMQ queue scheduler the job was never running and had been that way for more than 2 years. On that basis, after discussing it with the team it was agreed the job could be [ditched altogether](https://github.com/DEFRA/water-abstraction-service/pull/2494). 💪

To do its work it calls the `/crm/2.0/invoice-accounts/recently-updated` endpoint in this service. It's the only thing that does. This means with the job being deleted we can also delete that endpoint and its related code from this service!