### PR TITLE
Data fix for wrongly deleted document headers

### DIFF
--- a/migrations/20240816131334-fix-deleted-document-headers.js
+++ b/migrations/20240816131334-fix-deleted-document-headers.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240816131334-fix-deleted-document-headers-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240816131334-fix-deleted-document-headers-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240816131334-fix-deleted-document-headers-down.sql
+++ b/migrations/sqls/20240816131334-fix-deleted-document-headers-down.sql
@@ -1,0 +1,11 @@
+/* Revert the records to their previous state */
+
+BEGIN;
+
+UPDATE crm.document_header SET date_deleted = '2023-10-03 01:05:17.744' WHERE system_external_id = 'MD/054/0009/047';
+UPDATE crm.document_header SET date_deleted = '2023-10-03 01:05:17.744' WHERE system_external_id = 'MD/054/0009/055';
+UPDATE crm.document_header SET date_deleted = '2023-08-30 01:05:07.489' WHERE system_external_id = 'MD/054/0009/049';
+UPDATE crm.document_header SET date_deleted = '2021-09-02 01:05:01.482' WHERE system_external_id = '03/28/22/0033';
+UPDATE crm.document_header SET date_deleted = '2023-10-10 01:04:59.864' WHERE system_external_id = 'TH/039/0030/058';
+
+COMMIT;

--- a/migrations/sqls/20240816131334-fix-deleted-document-headers-up.sql
+++ b/migrations/sqls/20240816131334-fix-deleted-document-headers-up.sql
@@ -1,0 +1,16 @@
+/*
+  Data fix for wrongly deleted document headers
+
+  https://eaflood.atlassian.net/browse/WATER-4627
+
+  We received a report that an external user was unable to link MD/054/0009/047 to their account (it returned the error
+  "We cannot find these licence numbers"). We reproduced the issue in pre-prod and tracked down the cause.
+
+  We tracked the cause down to the document header having its `date_deleted` field populated when it shouldn't have
+  been. We were able to identify 4 other licences (document headers) that also shouldn't have had their `date_deleted`
+  fields populated.
+
+  This data fix sets the field back to NULL.
+*/
+
+UPDATE crm.document_header SET date_deleted = null WHERE system_external_id IN ('MD/054/0009/047', 'MD/054/0009/055', 'MD/054/0009/049', '03/28/22/0033', 'TH/039/0030/058');


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4627

We received a report that an external user was unable to link **MD/054/0009/047** to their account (it returned the error "We cannot find these licence numbers"). We reproduced the issue in pre-prod and tracked down the cause.

When you add a licence number, the legacy code runs this query to pull it from `CRM.document_headers`.

```sql
SELECT
  "crm"."document_header" .*
FROM
  "crm"."document_header"
WHERE
  "crm"."document_header"."system_external_id" = $1
  AND "crm"."document_header"."company_entity_id" IS NULL
  AND "crm"."document_header"."metadata"->'IsCurrent' != $2
  AND "crm"."document_header"."date_deleted" IS NULL
  AND "crm"."document_header"."metadata"->>'IsCurrent' != $3
ORDER BY
  "crm"."document_header"."system_external_id" ASC
LIMIT $4
-- [ 'MD/054/0009/047', 'false', 'false', 300 ]
```

On 2023-10-03 the [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import) marked the `crm.document_header` record as deleted. This is a step in the import process where it checks for deleted 'document'.

```javascript
// src/lib/connectors/import.js
const deleteCrmV1DocumentsQuery = `
  update crm.document_header
  set date_deleted = now()
  where system_external_id not in (
    select l."LIC_NO"
    from import."NALD_ABS_LICENCES" l
  )
  and date_deleted is null
  and regime_entity_id = '0434dc31-a34e-7158-5775-4694af7a60cf';
`
```

The knowledge of why the query didn't see this licence in the NALD data on that date is now lost to the universe! However, we can clearly see that the licence has a record in NALD, so it shouldn't have been picked up.

We've checked if others are affected, and fortunately, only 5 licences have a populated `date_deleted` though they have a matching record in the NALD data.

This change adds a migration data fix to reset the `date_deleted` to `null` for the 5 affected licences.