### PR TITLE
Alter CRM document unique constraints

### DIFF
--- a/migrations/20241014133216-alter-crm-v2-documents-defaults.js
+++ b/migrations/20241014133216-alter-crm-v2-documents-defaults.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20241014133216-alter-crm-v2-documents-defaults.js-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20241014133216-alter-crm-v2-documents-defaults.js-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20241014133216-alter-crm-v2-documents-defaults.js-down.sql
+++ b/migrations/sqls/20241014133216-alter-crm-v2-documents-defaults.js-down.sql
@@ -1,5 +1,9 @@
+BEGIN;
+
 -- Drop unique index on the licence number
-drop index crm_v2.documents_only_one_document_ref;
+DROP INDEX crm_v2.documents_only_one_document_ref;
 
 -- Create unique index on licence number
-create unique index documents_document_ref on crm_v2.documents(regime, document_type, document_ref);
+CREATE UNIQUE INDEX documents_document_ref ON crm_v2.documents(regime, document_type, document_ref);
+
+COMMIT;

--- a/migrations/sqls/20241014133216-alter-crm-v2-documents-defaults.js-down.sql
+++ b/migrations/sqls/20241014133216-alter-crm-v2-documents-defaults.js-down.sql
@@ -1,0 +1,5 @@
+-- Drop unique index on the licence number
+drop index crm_v2.documents_only_one_document_ref;
+
+-- Create unique index on licence number
+create unique index documents_document_ref on crm_v2.documents(regime, document_type, document_ref);

--- a/migrations/sqls/20241014133216-alter-crm-v2-documents-defaults.js-up.sql
+++ b/migrations/sqls/20241014133216-alter-crm-v2-documents-defaults.js-up.sql
@@ -1,5 +1,9 @@
+BEGIN;
+
 -- Drop unique index on licence number, document type and regime
-drop index crm_v2.documents_document_ref;
+DROP INDEX crm_v2.documents_document_ref;
 
 -- -- Create unique index on licence number
-create unique index documents_only_one_document_ref on crm_v2.documents(document_ref);
+CREATE UNIQUE INDEX documents_only_one_document_ref ON crm_v2.documents(document_ref);
+
+COMMIT;

--- a/migrations/sqls/20241014133216-alter-crm-v2-documents-defaults.js-up.sql
+++ b/migrations/sqls/20241014133216-alter-crm-v2-documents-defaults.js-up.sql
@@ -1,0 +1,5 @@
+-- Drop unique index on licence number, document type and regime
+drop index crm_v2.documents_document_ref;
+
+-- -- Create unique index on licence number
+create unique index documents_only_one_document_ref on crm_v2.documents(document_ref);


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4708

As part of the ongoing work to move the import code into WRLS. We need to use constraints to enforce data consistency and uniqueness.

Previously the document type and regime where defaulted and used to form a unique key. We no longer need to do this.

This chance simplifies the unique constraint to just the document ref (licence ref).