### PR TITLE
Data fix for multiple 'current' licence holders

### DIFF
--- a/migrations/20241223164630-fix-multiple-current-licence-holders.js
+++ b/migrations/20241223164630-fix-multiple-current-licence-holders.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20241223164630-fix-multiple-current-licence-holders-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20241223164630-fix-multiple-current-licence-holders-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20241223164630-fix-multiple-current-licence-holders-down.sql
+++ b/migrations/sqls/20241223164630-fix-multiple-current-licence-holders-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to correct invalid data */

--- a/migrations/sqls/20241223164630-fix-multiple-current-licence-holders-up.sql
+++ b/migrations/sqls/20241223164630-fix-multiple-current-licence-holders-up.sql
@@ -1,0 +1,36 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-4833
+
+  > Same issue as [PR 1052](https://github.com/DEFRA/water-abstraction-tactical-crm/pull/1052)
+
+  Users reported an issue with licence holder information.
+
+  - Two licence holders were listed on the view licence contact details page (there should only be one)
+  - When adding a new charge version, the journey was suggesting to create the new billing account using the old company
+    details
+
+  We found the issue was that for this licence, we have two entries in `crm_v2.document_roles` with the role of
+  `licenceHolder` and no end dates. In the case of the licence holder, the service derives the 'current' licence holder
+  by selecting the one with no end date (there should only be one).
+
+  Because we have 2 with no end date, view contact details shows both. In the legacy charge version journey, it gets all
+  licence roles for the licence, filters out any that are not 'licenceHolder', and then selects the first that meets
+  this criteria.
+
+  - Start date is before or the same as the chosen date for the new charge version
+  - End date is null or after the chosen date for the new charge version
+
+  Again, the old licence holder is the first record to meet these criteria; hence, the legacy code chooses it as the
+  'relevant company' to display.
+
+  In this example, we cannot ascertain what the cause of the data getting into this state was. Unlike WATER-4696 the
+  licence versions are in sync. But the fix is the same; delete the erroneous `crm_v2.document_roles` record.
+ */
+
+DELETE FROM crm_v2.document_roles
+WHERE
+  document_id = (
+    SELECT d.document_id FROM crm_v2.documents d WHERE d.document_ref = '6/33/12/*S/0022'
+  )
+  AND start_date = '2024-03-31'
+  AND end_date IS NULL;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4833

> Same issue as [PR 1052](https://github.com/DEFRA/water-abstraction-tactical-crm/pull/1052)

Specifically, `6/33/12/*S/0022` needs the fix. Users reported an issue with licence holder information.

- Two licence holders were listed on the view licence contact details page (there should only be one)
- When adding a new charge version, the journey was suggesting to create the new billing account using the old company details

We found the issue was that for this licence, we have two entries in `crm_v2.document_roles` with the role of `licenceHolder` and no end dates. In the case of the licence holder, the service derives the 'current' licence holder by selecting the one with no end date (there should only be one).

Because we have 2 with no end date, view contact details shows both. In the legacy charge version journey, it gets all licence roles for the licence, filters out any that are not 'licenceHolder', and then selects the first that meets this criteria.

- Start date is before or the same as the chosen date for the new charge version
- End date is null or after the chosen date for the new charge version

Again, the old licence holder is the first record to meet these criteria; hence, the legacy code chooses it as the 'relevant company' to display.

In this example, we cannot ascertain what the cause of the data getting into this state was. Unlike WATER-4696 the licence versions are in sync. But the fix is the same; delete the erroneous `crm_v2.document_roles` record.