### PR TITLE
Data fix to unlink users from deleted licences

### DIFF
--- a/migrations/20250702193402-fix-deleted-registered-licences.js
+++ b/migrations/20250702193402-fix-deleted-registered-licences.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250702193402-fix-deleted-registered-licences-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250702193402-fix-deleted-registered-licences-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250702193402-fix-deleted-registered-licences-down.sql
+++ b/migrations/sqls/20250702193402-fix-deleted-registered-licences-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to correct invalid data */

--- a/migrations/sqls/20250702193402-fix-deleted-registered-licences-up.sql
+++ b/migrations/sqls/20250702193402-fix-deleted-registered-licences-up.sql
@@ -1,0 +1,38 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-5038
+
+  We've updated the overnight import from NALD to include a clean-up step.
+
+  Now, records that exist in WRLS but don't exist in NALD will be deleted. That is, unless they are linked to something.
+
+  The following seven licences have been registered to user accounts but have since been deleted from NALD.
+
+  - 03/28/81/0045/1/RO1
+  - 6/33/48/\*S/0234/L
+  - 7/34/06/\*G/0279A/L
+  - AN/034/0006/017/L
+  - AN/034/0006/024/L
+  - AN/034/0009/004/L
+  - TH/039/0022/029/L
+
+  You should be able to unlink them through the UI, but that does not seem to be working in this case, likely due to the
+  legacy code not being compatible with the deletion of unrelated records.
+
+  If the unlink was working, all it does is set `company_entity_id` to null in the `crm.document_header` table for the
+  matching licence record. That is also all we need to do to allow the 'clean' process in
+  [water-abstraction-import](https://github.com/DEFRA/water-abstraction-system) to finally remove the remains of the
+  licence records.
+ */
+
+UPDATE crm.document_header SET
+  company_entity_id = NULL
+WHERE
+  system_external_id IN (
+    '03/28/81/0045/1/RO1',
+    '6/33/48/*S/0234/L',
+    '7/34/06/*G/0279A/L',
+    'AN/034/0006/017/L',
+    'AN/034/0006/024/L',
+    'AN/034/0009/004/L',
+    'TH/039/0022/029/L'
+  );


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5038

We've updated the overnight import from NALD to include a clean-up step.

Now, records that exist in WRLS but don't exist in NALD will be deleted. That is, unless they are linked to something.

The following seven licences have been registered to user accounts but have since been deleted from NALD.

- 03/28/81/0045/1/RO1
- 6/33/48/*S/0234/L
- 7/34/06/*G/0279A/L
- AN/034/0006/017/L
- AN/034/0006/024/L
- AN/034/0009/004/L
- TH/039/0022/029/L

You should be able to unlink them through the UI, but that does not seem to be working in this case, likely due to the legacy code not being compatible with the deletion of unrelated records.

If the unlink was working, all it does is set `company_entity_id` to null in the `crm.document_header` table for the matching licence record. That is also all we need to do to allow the 'clean' process in [water-abstraction-import](https://github.com/DEFRA/water-abstraction-system) to finally remove the remains of the licence records.