### PR TITLE
Switch to using Snyk CLI action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,40 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-MICROMATCH-6838728:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-06T08:29:48.140Z
+        created: 2025-08-07T08:29:48.141Z
+  SNYK-JS-KNEX-3175610:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-06T08:32:02.089Z
+        created: 2025-08-07T08:32:02.095Z
+  SNYK-JS-BRACES-6838727:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-06T08:32:32.931Z
+        created: 2025-08-07T08:32:32.938Z
+  SNYK-JS-UNSETVALUE-2400660:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-06T08:33:10.311Z
+        created: 2025-08-07T08:33:10.317Z
+  SNYK-JS-FORMDATA-10841150:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-06T08:34:11.920Z
+        created: 2025-08-07T08:34:11.927Z
+  SNYK-JS-REQUEST-3361831:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-06T08:34:44.900Z
+        created: 2025-08-07T08:34:44.906Z
+  SNYK-JS-TOUGHCOOKIE-5672873:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-06T08:35:07.662Z
+        created: 2025-08-07T08:35:07.668Z
+patch: {}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5191

With the adoption of SSO in the Defra GitHub org, our current [Snyk](https://snyk.io) status checks have stopped working.

The [team issue](https://github.com/DEFRA/water-abstraction-team/issues/144) goes into more detail, but in essence, whilst the GitHub account that **Snyk** uses to connect has SSO enabled, it won't connect to GitHub to update the PR with the test result.

This change performs the same check without **Snyk** having to authenticate to GitHub. Instead, GitHub will authenticate with **Snyk** by using its CLI via a GitHub action.

It does mean **Snyk** will no longer be listed as a separate check; instead, it will just be a new step in our CI. So, the outcome (adding a package with a vulnerability will cause the PR to fail checks) will be the same.