### PR TITLE
Delete missed billing company addresses 

### DIFF
--- a/migrations/20260624150619-delete-billing-company-addresses.js
+++ b/migrations/20260624150619-delete-billing-company-addresses.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260624150619-delete-billing-company-addresses-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260624150619-delete-billing-company-addresses-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20260624150619-delete-billing-company-addresses-down.sql
+++ b/migrations/sqls/20260624150619-delete-billing-company-addresses-down.sql
@@ -1,0 +1,1 @@
+/* No down script due to migration being used to delete redundant data */

--- a/migrations/sqls/20260624150619-delete-billing-company-addresses-up.sql
+++ b/migrations/sqls/20260624150619-delete-billing-company-addresses-up.sql
@@ -1,0 +1,32 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-5691
+
+  We recently added a data migration to
+  [Delete redundant billing contacts](https://github.com/DEFRA/water-abstraction-tactical-crm/pull/1142).
+
+  In summary, a bug reminded us that we have all this 'billing' CRM data that is no longer used. Rather than code around
+  the data, we should be getting rid of it.
+
+  We thought we had covered everything, but then spotted we'd missed `crm_v2.company_addresses`. These too have a
+  `role_id` which means they can be assigned to the company as a 'billing address'. But again, we don't use them as they
+  were replaced by the `crm_v2.invoice_account_addresses`.
+
+  This data migration deletes these records.
+ */
+
+WITH billing_company_addresses AS (
+  SELECT
+    ca.company_address_id
+  FROM
+    crm_v2.company_addresses ca
+  INNER JOIN
+    crm_v2.roles r
+    ON
+      r.role_id = ca.role_id
+  WHERE
+    r."name" = 'billing'
+)
+DELETE FROM
+  crm_v2.company_addresses ca
+WHERE
+  ca.company_address_id IN (SELECT company_address_id FROM billing_company_addresses);


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5691

We recently added a data migration to [Delete redundant billing contacts](https://github.com/DEFRA/water-abstraction-tactical-crm/pull/1142).

In summary, a bug reminded us that we have all this 'billing' CRM data that is no longer used. Rather than coding around the data, we should get rid of it.

We thought we had covered everything, but then spotted we'd missed `crm_v2.company_addresses`. These, too, have a `role_id` which means they can be assigned to the company as a 'billing address'. But again, we don't use them because they've been replaced by `crm_v2.invoice_account_addresses`.

This change adds another migration to remove the missed records.